### PR TITLE
feat: scraper pipeline, ircwiki source, Dokku deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.cache
+output
+.git

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to Dokku
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: improbib-deploy
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup SSH
+        run: |
+          install -m 700 -d ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 -d > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          echo "${{ secrets.KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy to Dokku
+        run: |
+          git remote add dokku dokku@impromat.app:improbib
+          git push dokku main

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,9 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
+# Personal project notes
+TODO.md
+
 # IntelliJ based IDEs
 .idea
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1-alpine
+
+WORKDIR /app
+COPY package.json bun.lockb ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+ENV STORAGE_PATH=/app/storage
+
+CMD ["bun", "run", "src/serve.ts"]

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,8 +1,10 @@
 import { Improbib } from ".";
 
+const testMode = Bun.argv.includes("--test");
+
 const scraper = new Improbib();
 
 await scraper.enableLogging();
-await scraper.scrapeLearnImprov();
+await scraper.scrape(testMode ? { maxPagesPerListing: 1 } : {});
 
 console.log("Done.");

--- a/src/assemble.ts
+++ b/src/assemble.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import path from "path";
+import type { ElementType } from "./scraping/shared/element-type";
+import { mergeElements } from "./scraping/shared/merge-elements";
+import { convertHtmlToMarkdown } from "./scraping/shared/process-markdown";
+import {
+  transformAndTranslateTags,
+} from "./scraping/shared/transform-and-translate-tags";
+import { improbibSchema } from "./validation/improbib-schema";
+
+const SOURCES = ["improwiki", "learnimprov", "ircwiki"] as const;
+
+async function loadRawJson(
+  sourceName: string
+): Promise<{ meta: Record<string, any>; elements: ElementType[] }> {
+  const rawFile = path.join(
+    process.cwd(),
+    "output",
+    "raw",
+    `${sourceName}.json`
+  );
+  try {
+    const raw = JSON.parse(await fs.readFile(rawFile, "utf-8"));
+    return { meta: raw.meta || {}, elements: raw.elements || [] };
+  } catch {
+    console.warn(`Raw file not found for ${sourceName}, skipping`);
+    return { meta: {}, elements: [] };
+  }
+}
+
+export async function assemble() {
+  const allOutputs: {
+    meta: Record<string, any>;
+    elements: ElementType[];
+  } = { meta: {}, elements: [] };
+
+  for (const source of SOURCES) {
+    const { meta, elements } = await loadRawJson(source);
+    console.log(
+      `Loaded ${elements.length} elements from ${source}`
+    );
+    allOutputs.elements.push(...elements);
+    Object.assign(allOutputs.meta, meta);
+  }
+
+  console.log(
+    `Total elements before merge: ${allOutputs.elements.length}`
+  );
+
+  mergeElements(allOutputs);
+
+  console.log(
+    `Total elements after merge: ${allOutputs.elements.length}`
+  );
+
+  convertHtmlToMarkdown(allOutputs.elements);
+
+  transformAndTranslateTags(allOutputs);
+
+  let dropped = 0;
+  allOutputs.elements = allOutputs.elements.filter((e) => {
+    const markdownLen = (e.markdown as string)?.length ?? 0;
+    const tagIdsLen = (e.tagIds as string[])?.length ?? 0;
+    if (markdownLen < 10 || tagIdsLen === 0) {
+      console.warn(
+        `Dropping element ${e.name}: markdown=${markdownLen} chars, tagIds=${tagIdsLen}`
+      );
+      dropped++;
+      return false;
+    }
+    return true;
+  });
+  if (dropped) console.log(`Dropped ${dropped} elements with insufficient content`);
+
+  for (const e of allOutputs.elements) {
+    const md = e.markdown as string;
+    if (md.length > 10000) {
+      e.markdown = md.slice(0, 10000);
+    }
+  }
+
+  const result = improbibSchema.safeParse(allOutputs);
+  if (!result.success) {
+    console.error("Schema validation errors:");
+    for (const issue of result.error.issues) {
+      console.error(`  ${issue.path.join(".")}: ${issue.message}`);
+    }
+  } else {
+    console.log("Schema validation passed");
+  }
+
+  allOutputs.meta.assembly = {
+    sourceCounts: SOURCES.reduce(
+      (acc, source) => {
+        acc[source] = allOutputs.elements.filter(
+          (e) => e.sourceName === source
+        ).length;
+        return acc;
+      },
+      {} as Record<string, number>
+    ),
+    totalElements: allOutputs.elements.length,
+  };
+
+  const outputDir = path.join(process.cwd(), "output");
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const outputFile = path.join(outputDir, "improbib.json");
+  await fs.writeFile(outputFile, JSON.stringify(allOutputs, null, 2), "utf-8");
+  console.log(`Wrote ${outputFile}`);
+
+  return allOutputs;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import { initLogging } from "./logger";
 import { scrapeImprowiki } from "./scrape-improwiki";
 import { scrapeLearnImprov } from "./scraping/learnimprov/scrape-learnimprov";
+import { scrapeIrcWiki } from "./scraping/ircwiki/scrape-ircwiki";
+import { assemble } from "./assemble";
 import { improbibSchema } from "./validation/improbib-schema";
 
 export class Improbib {
@@ -9,10 +11,12 @@ export class Improbib {
     await initLogging();
   }
 
-  async scrape() {
-    await scrapeImprowiki();
-    await scrapeLearnImprov();
+  async scrape(options?: { maxPagesPerListing?: number }) {
+    await scrapeImprowiki(options);
+    await scrapeLearnImprov(options);
+    await scrapeIrcWiki(options);
     console.log("All sources scraped.");
+    await assemble();
   }
 
   async scrapeImprowiki() {
@@ -21,6 +25,14 @@ export class Improbib {
 
   async scrapeLearnImprov() {
     return await scrapeLearnImprov();
+  }
+
+  async scrapeIrcWiki() {
+    return await scrapeIrcWiki();
+  }
+
+  async assemble() {
+    return await assemble();
   }
 }
 

--- a/src/scrape-improwiki.ts
+++ b/src/scrape-improwiki.ts
@@ -27,7 +27,9 @@ async function shouldFetch(
   return sitemapLastmod > existingLastmod;
 }
 
-export async function scrapeImprowiki() {
+export async function scrapeImprowiki(
+  options?: { maxPagesPerListing?: number }
+) {
   const { elements: existingElements, urlMap } =
     await loadExistingElements("improwiki");
 
@@ -106,7 +108,10 @@ export async function scrapeImprowiki() {
     const newElements = await processImprowikiEntryPage(
       baseUrl,
       entryPage.url,
-      (url) => shouldFetch(url, urlMap, sitemap)
+      {
+        shouldFetch: (url) => shouldFetch(url, urlMap, sitemap),
+        maxPagesPerListing: options?.maxPagesPerListing,
+      }
     );
 
     elements = [

--- a/src/scraping/improwiki/process-improwiki-entry-page.ts
+++ b/src/scraping/improwiki/process-improwiki-entry-page.ts
@@ -7,8 +7,12 @@ import { processImprowikiPage } from "./process-improwiki-page";
 export async function processImprowikiEntryPage(
   baseUrl: string,
   url: string,
-  shouldFetch?: (url: string) => Promise<boolean>
+  options?: {
+    shouldFetch?: (url: string) => Promise<boolean>;
+    maxPagesPerListing?: number;
+  }
 ) {
+  const { shouldFetch, maxPagesPerListing } = options ?? {};
   const logger = appLogger.getChild("processImprowikiEntryPage");
   const entryPage = await fetchAndCacheWebsite(url);
   logger.info(`Processing entry page ${entryPage.url}`);
@@ -34,6 +38,10 @@ export async function processImprowikiEntryPage(
     logger.info(
       `  ${toFetch.length} new/changed, ${skipped} unchanged`
     );
+  }
+
+  if (maxPagesPerListing !== undefined && toFetch.length > maxPagesPerListing) {
+    toFetch = toFetch.slice(0, maxPagesPerListing);
   }
 
   const startTime = Date.now();

--- a/src/scraping/improwiki/process-markdown.ts
+++ b/src/scraping/improwiki/process-markdown.ts
@@ -1,39 +1,28 @@
-import TurndownService from "turndown";
-import { appLogger } from "../../logger";
 import type { ElementType } from "../shared/element-type";
+import { convertHtmlToMarkdown } from "../shared/process-markdown";
 import { processMarkdownOfElement } from "./process-markdown-of-element";
 
 /**
- * Transforms html content to markdown and cleans markdown.
- *
- * @param output
+ * Transforms html content to markdown and cleans markdown (improwiki-specific).
  */
 export async function processMarkdown(output: {
   meta: Record<string, any>;
   elements: ElementType[];
 }) {
-  const turndownService = new TurndownService({
-    headingStyle: "atx",
-  });
   const { elements } = output;
-  const logger = appLogger.getChild("processMarkdown");
-  logger.info("Processing markdown");
 
   for (const element of elements) {
     if (element.identifier === "19911874ee7c6a99e23ca40ed4be969a") {
-      // TODO make ignore list for elements
-      // or better: mark the element quality as BAD
       element.markdown = "";
       continue;
     }
-    logger.debug(`Processing markdown for ${element.htmlContent}`);
-    if (element.htmlContent && typeof element.htmlContent === "string") {
-      element.markdown = turndownService.turndown(element.htmlContent);
+  }
+
+  convertHtmlToMarkdown(elements);
+
+  for (const element of elements) {
+    if (element.markdown) {
       processMarkdownOfElement(element);
-    } else {
-      logger.warn(
-        `Element ${element.name} (${element.identifier}) has no htmlContent`
-      );
     }
   }
 }

--- a/src/scraping/ircwiki/process-ircwiki-category-page.ts
+++ b/src/scraping/ircwiki/process-ircwiki-category-page.ts
@@ -1,0 +1,16 @@
+import { load } from "cheerio";
+import { fetchAndCacheWebsite } from "../shared/fetch-and-cache-website";
+
+const DELAY_MS = 10000;
+
+export async function processIrcWikiCategoryPage(url: string) {
+  const page = await fetchAndCacheWebsite(url, { delayMs: DELAY_MS });
+  const $ = load(page.html);
+
+  const postUrls = $("#mw-pages a")
+    .map((_, el) => $(el).attr("href"))
+    .toArray()
+    .filter((href): href is string => !!href);
+
+  return postUrls;
+}

--- a/src/scraping/ircwiki/process-ircwiki-page.ts
+++ b/src/scraping/ircwiki/process-ircwiki-page.ts
@@ -1,0 +1,71 @@
+import { load } from "cheerio";
+import { appLogger } from "../../logger";
+import { fetchAndCacheWebsite } from "../shared/fetch-and-cache-website";
+import type { ElementType } from "../shared/element-type";
+
+const DELAY_MS = 10000;
+
+function parseLastModified(text: string): string | undefined {
+  const match = text.match(
+    /on (\d{1,2})\s+(\w+)\s+(\d{4}),\s+at\s+(\d{2}):(\d{2})/
+  );
+  if (match) {
+    const [, day, month, year, hour, minute] = match;
+    return new Date(`${month} ${day}, ${year} ${hour}:${minute}:00 UTC`).toISOString();
+  }
+  return undefined;
+}
+
+export async function processIrcWikiPage(
+  url: string,
+  addTags: string[]
+): Promise<ElementType | undefined> {
+  const logger = appLogger.getChild("processIrcWikiPage");
+  logger.debug(`Fetching ${url}`);
+  const page = await fetchAndCacheWebsite(url, { delayMs: DELAY_MS });
+  const $ = load(page.html);
+
+  const title = $("#firstHeading").first().text().trim();
+  if (!title) {
+    logger.debug(`No title found in: ${url}`);
+    return undefined;
+  }
+
+  const htmlContent = $("#mw-content-text").html() ?? "";
+
+  const categories = $("#catlinks #mw-normal-catlinks ul li a")
+    .map((_, el) => $(el).text().trim())
+    .toArray()
+    .filter((cat) => cat && cat !== "All");
+
+  const lastModifiedText = $("#footer li#lastmod").text().trim();
+  const lastModified = parseLastModified(lastModifiedText);
+
+  const tags = [...addTags, ...categories];
+
+  const hasher = new Bun.CryptoHasher("md5");
+  hasher.update(`element;${title};${url}`);
+  logger.debug(`Hashing ${title} ${url}`);
+  const identifier = hasher.digest("hex");
+
+  const sourceName = "ircwiki";
+  const license = {
+    licenseName: "GNU Free Documentation License 1.2",
+    licenseSpdxIdentifier: "GFDL-1.2",
+    licenseUrl: "https://www.gnu.org/copyleft/fdl.html",
+  };
+
+  return {
+    identifier,
+    url,
+    name: title,
+    tags,
+    categories,
+    languageCode: "en",
+    sourceName,
+    htmlContent,
+    fetchedAt: page.date.toISOString(),
+    lastModified,
+    ...license,
+  };
+}

--- a/src/scraping/ircwiki/scrape-ircwiki.ts
+++ b/src/scraping/ircwiki/scrape-ircwiki.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs/promises";
+import path from "path";
+import type { ElementType } from "../shared/element-type";
+import { loadExistingElements } from "../shared/load-existing-elements";
+import { mergeElements } from "../shared/merge-elements";
+import { processIrcWikiCategoryPage } from "./process-ircwiki-category-page";
+import { processIrcWikiPage } from "./process-ircwiki-page";
+
+const BASE_URL = "https://wiki.improvresourcecenter.com";
+
+function resolveUrl(href: string): string {
+  if (href.startsWith("http")) return href;
+  return BASE_URL + href;
+}
+
+export async function scrapeIrcWiki(options?: { maxPagesPerListing?: number }) {
+  const { elements: existingElements, urlMap } =
+    await loadExistingElements("ircwiki");
+
+  console.log(`Loaded ${existingElements.length} existing elements`);
+
+  const listingPages = [
+    {
+      url: `${BASE_URL}/index.php?title=Category:Improv_Forms`,
+      addTags: ["Improv Form"],
+    },
+    {
+      url: `${BASE_URL}/index.php?title=Category:Concepts`,
+      addTags: ["Concept"],
+    },
+    {
+      url: `${BASE_URL}/index.php?title=Category:Openings`,
+      addTags: ["Opening"],
+    },
+    {
+      url: `${BASE_URL}/index.php?title=Category:Editing_Techniques`,
+      addTags: ["Editing Technique"],
+    },
+    {
+      url: `${BASE_URL}/index.php?title=Category:Exercises`,
+      addTags: ["Exercise"],
+    },
+    {
+      url: `${BASE_URL}/index.php?title=Category:Improv_Games`,
+      addTags: ["Improv Game"],
+    },
+  ];
+
+  let newElements: ElementType[] = [];
+
+  for (const listingPage of listingPages) {
+    console.log(`Processing listing page: ${listingPage.url}`);
+    const relativeUrls = await processIrcWikiCategoryPage(listingPage.url);
+    console.log(`Found ${relativeUrls.length} pages`);
+
+    const toFetch: string[] = [];
+    let skipped = 0;
+    for (const relativeUrl of relativeUrls) {
+      const postUrl = resolveUrl(relativeUrl);
+      if (urlMap.has(postUrl)) {
+        skipped++;
+      } else {
+        toFetch.push(postUrl);
+      }
+    }
+
+    console.log(
+      `  Fetching ${toFetch.length} new, skipping ${skipped} existing`
+    );
+
+    if (toFetch.length === 0) continue;
+
+    const urls = options?.maxPagesPerListing
+      ? toFetch.slice(0, options.maxPagesPerListing)
+      : toFetch;
+
+    let fetched = 0;
+
+    for (const postUrl of urls) {
+      const element = await processIrcWikiPage(postUrl, listingPage.addTags);
+      if (element) {
+        newElements.push(element);
+      }
+      fetched++;
+      if (fetched % 5 === 0 || fetched === urls.length) {
+        console.log(`  Progress: ${fetched}/${urls.length} pages`);
+      }
+    }
+  }
+
+  console.log(`New elements fetched: ${newElements.length}`);
+  console.log(`Reusing ${existingElements.length} existing elements`);
+
+  const allElements = [...existingElements, ...newElements];
+
+  const output: { meta: Record<string, any>; elements: ElementType[] } = {
+    meta: {},
+    elements: allElements,
+  };
+
+  mergeElements(output);
+
+  console.log(`Total elements after merge: ${output.elements.length}`);
+
+  output.meta.inventory = {
+    elementCount: output.elements.length,
+    newFetched: newElements.length,
+    reused: existingElements.length,
+  };
+
+  const rawDir = path.join(process.cwd(), "output", "raw");
+  const filesDir = path.join(rawDir, "files");
+  await fs.mkdir(filesDir, { recursive: true });
+
+  for (const element of output.elements) {
+    if (!element.htmlContentPath) {
+      const htmlFile = path.join(filesDir, `${element.identifier}.html`);
+      await fs.writeFile(htmlFile, element.htmlContent as string, "utf-8");
+      element.htmlContentPath = htmlFile;
+    }
+  }
+
+  output.elements = output.elements.sort((a, b) =>
+    a.identifier.localeCompare(b.identifier)
+  );
+
+  const outputFile = path.join(rawDir, "ircwiki.json");
+  await fs.writeFile(outputFile, JSON.stringify(output, null, 2), "utf-8");
+  console.log(`Raw elements written to ${outputFile}`);
+
+  return output;
+}

--- a/src/scraping/learnimprov/scrape-learnimprov.ts
+++ b/src/scraping/learnimprov/scrape-learnimprov.ts
@@ -27,7 +27,9 @@ async function shouldFetch(
   return sitemapLastmod > existingLastmod;
 }
 
-export async function scrapeLearnImprov() {
+export async function scrapeLearnImprov(
+  options?: { maxPagesPerListing?: number }
+) {
   const { elements: existingElements, urlMap } =
     await loadExistingElements("learnimprov");
 
@@ -73,9 +75,13 @@ export async function scrapeLearnImprov() {
 
     if (toFetch.length === 0) continue;
 
+    const urls = options?.maxPagesPerListing
+      ? toFetch.slice(0, options.maxPagesPerListing)
+      : toFetch;
+
     let fetched = 0;
 
-    for (const postUrl of toFetch) {
+    for (const postUrl of urls) {
       const element = await processLearnImprovPost(
         postUrl,
         listingPage.addTags
@@ -84,8 +90,8 @@ export async function scrapeLearnImprov() {
         newElements.push(element);
       }
       fetched++;
-      if (fetched % 10 === 0 || fetched === toFetch.length) {
-        console.log(`  Progress: ${fetched}/${toFetch.length} posts`);
+      if (fetched % 10 === 0 || fetched === urls.length) {
+        console.log(`  Progress: ${fetched}/${urls.length} posts`);
       }
     }
   }

--- a/src/scraping/shared/fetch-and-cache-website.ts
+++ b/src/scraping/shared/fetch-and-cache-website.ts
@@ -10,12 +10,16 @@ interface Page {
 
 const pendingFetches = new Map<string, Promise<Page>>();
 
-const DELAY_MS = 500;
+const DEFAULT_DELAY_MS = 500;
 
 let lastFetchTime = 0;
 let backoffMs = 0;
 
-export async function fetchAndCacheWebsite(url: string): Promise<Page> {
+export async function fetchAndCacheWebsite(
+  url: string,
+  options?: { delayMs?: number }
+): Promise<Page> {
+  const delayMs = options?.delayMs ?? DEFAULT_DELAY_MS;
   const logger = appLogger.getChild("fetchAndCacheWebsite");
 
   if (pendingFetches.has(url)) {
@@ -48,7 +52,7 @@ export async function fetchAndCacheWebsite(url: string): Promise<Page> {
 
     while (true) {
       const now = Date.now();
-      const wait = Math.max(0, DELAY_MS + backoffMs - (now - lastFetchTime));
+      const wait = Math.max(0, delayMs + backoffMs - (now - lastFetchTime));
       if (wait > 0) {
         await new Promise((r) => setTimeout(r, wait));
       }

--- a/src/scraping/shared/process-markdown.ts
+++ b/src/scraping/shared/process-markdown.ts
@@ -1,0 +1,22 @@
+import TurndownService from "turndown";
+import { appLogger } from "../../logger";
+import type { ElementType } from "./element-type";
+
+export function convertHtmlToMarkdown(elements: ElementType[]) {
+  const turndownService = new TurndownService({
+    headingStyle: "atx",
+  });
+  const logger = appLogger.getChild("convertHtmlToMarkdown");
+  logger.info("Processing markdown");
+
+  for (const element of elements) {
+    logger.debug(`Processing markdown for ${element.name}`);
+    if (element.htmlContent && typeof element.htmlContent === "string") {
+      element.markdown = turndownService.turndown(element.htmlContent);
+    } else {
+      logger.warn(
+        `Element ${element.name} (${element.identifier}) has no htmlContent`
+      );
+    }
+  }
+}

--- a/src/scraping/shared/tag-transformations.ts
+++ b/src/scraping/shared/tag-transformations.ts
@@ -73,7 +73,7 @@ export const tagTransformations = {
   ÜbungenAssoziieren: ["Übung", "Assoziieren"],
   "ÜbungenAngebot/Annahme": ["Übung", "Angebot", "Annahme"],
   ÜbungenAkzeptieren: ["Übung", "Annahme"],
-  Begriffserklärungen: [],
+  Begriffserklärungen: ["other"],
   ÜbungenAtmung: ["Übung", "Atmung"],
   "ÜbungenMusik und Gesang": ["Übung", "Musik", "Gesang"],
   Expression: ["Expression"],

--- a/src/scraping/shared/transform-and-translate-tags.ts
+++ b/src/scraping/shared/transform-and-translate-tags.ts
@@ -48,12 +48,14 @@ export function transformAndTranslateTags(output: {
   // add translated tags to element
   for (const element of elements) {
     appLogger.debug("element {element}", { element });
-    element["translatedTags"] = (element.tagIds as string[]).map(
-      (tagId) =>
-        tagTranslations[tagId as keyof typeof tagTranslations][
-          element.languageCode as "de" | "en"
-        ]
-    );
+    element["translatedTags"] = (element.tagIds as string[]).map((tagId) => {
+      const translation =
+        tagTranslations[tagId as keyof typeof tagTranslations];
+      if (!translation) {
+        return tagId;
+      }
+      return translation[element.languageCode as "de" | "en"] ?? tagId;
+    });
     element["translatedTags"] = [...new Set(element["translatedTags"])];
   }
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,0 +1,108 @@
+import { mkdir } from "node:fs/promises";
+
+const storagePath = process.env.STORAGE_PATH || process.cwd();
+await mkdir(storagePath, { recursive: true });
+process.chdir(storagePath);
+
+import { Improbib } from ".";
+import { readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { gzipSync } from "node:zlib";
+import path from "path";
+
+const PORT = parseInt(process.env.PORT || "5000");
+
+function jsonResponse(data: unknown, req: Request): Response {
+  const body = JSON.stringify(data, null, 2);
+  const headers: Record<string, string> = {
+    "content-type": "application/json; charset=utf-8",
+    "access-control-allow-origin": "*",
+  };
+
+  if (req.headers.get("accept-encoding")?.includes("gzip")) {
+    const compressed = gzipSync(Buffer.from(body));
+    headers["content-encoding"] = "gzip";
+    return new Response(compressed, { headers });
+  }
+
+  return new Response(body, { headers });
+}
+
+function serveFile(filePath: string, req: Request): Response | null {
+  if (!existsSync(filePath)) return null;
+
+  const content = readFileSync(filePath, "utf-8");
+  return jsonResponse(JSON.parse(content), req);
+}
+
+function serveDir(dirPath: string): string[] {
+  if (!existsSync(dirPath)) return [];
+
+  const { readdirSync } = require("node:fs") as typeof import("node:fs");
+  return readdirSync(dirPath, { withFileTypes: true })
+    .filter((d: { isFile: () => boolean }) => d.isFile())
+    .map((d: { name: string }) => d.name);
+}
+
+const scanner = new Improbib();
+await scanner.enableLogging();
+
+async function runScrape() {
+  console.log(`[${new Date().toISOString()}] Starting scrape...`);
+  try {
+    await scanner.scrape();
+    console.log(`[${new Date().toISOString()}] Scrape complete.`);
+  } catch (err) {
+    console.error(`[${new Date().toISOString()}] Scrape failed:`, err);
+  }
+}
+
+let lastRunDate: string | null = null;
+
+setInterval(async () => {
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  if (now.getUTCHours() === 4 && lastRunDate !== today) {
+    lastRunDate = today;
+    await runScrape();
+  }
+}, 60_000);
+
+console.log(`[${new Date().toISOString()}] Starting HTTP server on port ${PORT}...`);
+Bun.serve({
+  port: PORT,
+  fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/" || url.pathname === "/status") {
+      const storage = process.env.STORAGE_PATH || process.cwd();
+      const rawDir = path.join(storage, "output", "raw");
+      const files = serveDir(rawDir);
+      const improbableExists = existsSync(path.join(storage, "output", "improbib.json"));
+
+      return jsonResponse({
+        storage,
+        sources: files.filter((f) => f.endsWith(".json")),
+        improbableBuilt: improbableExists,
+      }, req);
+    }
+
+    if (url.pathname === "/improbib.json") {
+      const res = serveFile(path.join(process.cwd(), "output", "improbib.json"), req);
+      if (res) return res;
+    }
+
+    if (url.pathname.startsWith("/raw/")) {
+      const fileName = path.basename(url.pathname);
+      const res = serveFile(path.join(process.cwd(), "output", "raw", fileName), req);
+      if (res) return res;
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+});
+
+console.log(`Server listening on http://0.0.0.0:${PORT}`);
+
+console.log(`[${new Date().toISOString()}] Running initial scrape in background...`);
+runScrape();

--- a/src/validation/improbib-schema.ts
+++ b/src/validation/improbib-schema.ts
@@ -20,7 +20,11 @@ export const improbibSchema = z.object({
         tagIds: z.array(z.string()).min(1),
         licenseUrl: z.string().url(),
         translatedTags: z.array(z.string().min(2).max(40)).nonempty(),
-        licenseSpdxIdentifier: z.string().includes("CC-BY-SA-3.0-DE"),
+        licenseSpdxIdentifier: z.enum([
+          "CC-BY-SA-3.0-DE",
+          "CC-BY-SA-4.0",
+          "GFDL-1.2",
+        ]),
         licenseName: z.string(),
 
         playerCountMin: z.number().optional(),


### PR DESCRIPTION
## Changes (June 2, 2026)

### Pipeline
- Add assembly step combining improwiki, learnimprov, ircwiki raw outputs into `improbib.json`
- Add shared HTML→Markdown conversion pipeline (TurndownService)
- Add `--test` flag for fast pipeline validation with limited page fetches

### New source
- Add ircwiki scraper (wiki.improvresourcecenter.com, GFDL-1.2 license, 10s crawl-delay)

### Data quality
- Filter stub pages (markdown < 10 chars, empty tagIds)
- Truncate markdown > 10000 chars
- Fix license validation to enum
- Fix tag translation crash on unknown tags

### Deployment
- Dockerfile (oven/bun:1-alpine)
- serve.ts: Bun HTTP server + daily scraper scheduler at 4am UTC
- GitHub Actions deploy workflow (git push dokku on main)
- Personal-infra Dokku app: `improbib.host.impromat.app`, storage mount, SSL

### Live at
`https://improbib.host.impromat.app/improbib.json` — 1,265 elements across 3 sources