### PR TITLE
feat: content normalization layer (Layer 1.5)

### DIFF
--- a/docs/adrs/0008-normalization-layer.md
+++ b/docs/adrs/0008-normalization-layer.md
@@ -1,0 +1,88 @@
+# ADR-0008: Content Normalization Layer
+
+- **Date**: 2026-06-03
+- **Status**: accepted
+- **Source**: cross-cutting
+
+## Context
+
+Raw scraped content is unstructured HTML. A single improwiki page may contain a game description, inline variations, tips, pedagogical notes, and cross-references — all as flat markup. Feeding this directly into knowledge graph derivation (Layer 2) produces unreliable extraction. We need a structured intermediate representation.
+
+## Decision
+
+### Two-step extraction
+
+1. **Golden test set** — 15 hand-verified elements with expected outputs serve as the ground truth for model comparison. This is committed to the repo (`src/normalize/__testdata__/golden-set.ts`) and can benchmark any model.
+
+2. **LLM extraction pipeline** (`src/normalize/normalize.ts`) — For each raw element, convert HTML to markdown (Turndown), send to an LLM with a structured extraction prompt, validate against a Zod schema, and write per-source output to `output/normalized/{source}.json`.
+
+### Model selection
+
+We benchmarked `opencode-go/deepseek-v4-flash` against `opencode-go/deepseek-v4-pro` using the golden test set. Results with OpenCode 1.15.5:
+
+| Metric | Pro | Flash |
+|--------|-----|-------|
+| Descriptions | 100% | 100% |
+| howToPlay | 100% | 100% |
+| Variation recall | 93% | 100% |
+| Tip recall | 71% | 51% |
+| Reference recall | 93% | 93% |
+| **Overall** | **93%** | **91%** |
+
+Both models are viable. Flash is faster (~80s vs ~190s for 15 elements) and free on the OpenCode Go plan. We default to flash for normalization but keep pro as a reference for benchmarking. The benchmark script supports adding new models trivially (one line in the MODELS array).
+
+### LLM client architecture
+
+The LLM client (`src/normalize/llm-client.ts`) shells out to `opencode run` via `Bun.spawn`. This was chosen over:
+- **Direct HTTP API**: The OpenCode Go API endpoint is not a standard OpenAI-compatible chat completions endpoint; it routes through opencode's internal gateway. Direct HTTP calls returned "Not Found" on all tested URL patterns.
+- **OpenCode SDK**: Requires an additional npm dependency and runs a full opencode server process. Overhead not justified for batch extraction.
+
+The CLI approach uses the existing `~/.local/share/opencode/auth.json`, needs no extra authentication setup, and is the same mechanism powering the opencode TUI.
+
+### Output format
+
+Each source produces `output/normalized/{source}.json` with the schema defined in `src/normalize/normalized-schema.ts`:
+
+```typescript
+{
+  meta: { sourceName, elementCount, derivedElementCount, normalizedAt },
+  elements: [{
+    // ... raw fields preserved verbatim (identifier, name, url, tags, htmlContent, etc.)
+    normalized: {
+      description: string,          // 1-3 sentences
+      howToPlay: string | null,     // null for concepts only
+      variations: { name, description }[],
+      tips: string[],
+      referencedElements: string[],
+      contentHash: string,          // md5 of htmlContent for change detection
+      extractedAt: string,          // ISO timestamp
+    },
+    derivedElements: [{ name, description, parentIdentifier }], // from inline variations
+  }]
+}
+```
+
+### Change detection
+
+Each normalized element stores `contentHash = md5(htmlContent)`. On re-normalization, elements whose hash matches the previous run are preserved unchanged. Only changed or new elements trigger an LLM call.
+
+### Derived sub-elements
+
+Inline variations with descriptions > 40 chars are promoted to `derivedElements`. These are candidate sub-elements that lack dedicated source pages. They are clearly marked to distinguish them from scraped elements. Human QA (Layer 2.5) can accept or reject them.
+
+### Cross-source deduplication
+
+**Deferred.** Deduplicating elements across sources (e.g., "Freeze Tag" appearing on both improwiki and learnimprov) requires fuzzy name matching and LLM confirmation. This is a graph-layer concern (Layer 2). The normalization layer keeps per-source output and adds `referencedElements` cross-references.
+
+## Consequences
+
+### Enables
+- Reliable structured extraction for graph derivation (Layer 2)
+- Model-agnostic benchmarking via the golden test set
+- Incremental updates (content hash caching)
+- Derived sub-element discovery from inline variations
+
+### Risks
+- CLI-based LLM client adds ~2s per element (startup overhead). With 1355 elements, a full normalization pass takes ~45 minutes. This is acceptable for a batch process.
+- Flash model has lower tip recall (51%) — this is a prompt engineering issue, not a model capability gap. The benchmark provides a feedback loop for prompt iteration.
+- No cross-source deduplication in this layer — graph layer must handle it.

--- a/docs/plans/0001-knowledge-graph-and-application.md
+++ b/docs/plans/0001-knowledge-graph-and-application.md
@@ -1,0 +1,212 @@
+# Plan 0001: Knowledge Graph & Application
+
+## Vision
+
+Improvisation theater has no structured, cross-source database connecting games, exercises, shows, skills, and mechanics. Existing resources (improwiki, learnimprov, IRC Wiki) are siloed, their tag systems are flat and source-specific, and workshop/show planning relies entirely on personal knowledge.
+
+**Goal**: Derive a knowledge graph from scraped improv sources, enable human quality control, and build a workshop/show planning application on top of it.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Layer 3: Application                                            │
+│ Workshop planner · Show set builder · Element browser           │
+│ Consumes graph.json — has no knowledge of sources or scraping   │
+├──────────────────────────────────────────────────────────────────┤
+│ Layer 2.5: Human QA                                 │
+│ Review, correct, enrich edges                      │
+│ Produces overrides that merge into the final graph │
+├──────────────────────────────────────────────────────────────────┤
+│ Layer 2: Knowledge Graph Derivation                             │
+│ Consumes normalized elements                                    │
+│ LLM extraction + heuristics → draft graph                       │
+│ Merges human QA overrides → output/graph.json                   │
+├──────────────────────────────────────────────────────────────────┤
+│ Layer 1.5: Content Normalization             │
+│ Structures raw markdown into sections        │
+│ Extracts inline variations as sub-elements   │
+│ Extracts cross-references between elements   │
+│ → output/normalized/{source}.json            │
+├──────────────────────────────────────────────────────────────────┤
+│ Layer 1: Raw Sources (exists)                                   │
+│ improwiki.com · learnimprov.com · wiki.improvresourcecenter.com │
+│ Scrapes HTML + metadata → output/raw/{source}.json              │
+│ Per ADR-0001 through ADR-0007                                   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Data flows one direction. Each layer produces a stable artifact, enabling independent iteration on downstream layers without re-running upstream ones.
+
+## Layer 1: Raw Sources (exists)
+
+Scrapes source websites, extracts metadata and raw HTML, resolves cross-page links (translation links), deduplicates by identifier. Each source produces `output/raw/{source}.json`.
+
+This layer is already built. Existing ADRs document the decisions.
+
+## Layer 1.5: Content Normalization
+
+### Problem
+
+Source content is inconsistently structured. A single page may contain a game description, inline variations, tips, cross-references to other games, and pedagogical notes — all as unstructured markdown. Feeding this directly into graph derivation produces unreliable extraction.
+
+### What it does
+
+For each element, an LLM pass structures the raw markdown into clean fields:
+
+| Field | Content |
+|---|---|
+| `description` | 1–3 sentence summary of what the element is |
+| `howToPlay` | Step-by-step instructions |
+| `variations` | Named variations described inline, with their own short descriptions |
+| `tips` | Pedagogical notes, common pitfalls, teacher advice |
+| `referencedElements` | Names of other elements mentioned in the text |
+
+The original markdown is preserved unchanged. The structured fields augment it.
+
+### Inline variations → candidate sub-elements
+
+When a source page describes a variation that has no dedicated page of its own, normalization promotes it to a **derived sub-element**. Example:
+
+- Source page: "Freeze Tag" describes "Emotional Freeze Tag" as a one-paragraph variation
+- Normalization output: `Emotional Freeze Tag` becomes a candidate element with `derivedFrom: "Freeze Tag"` and `sourcedFrom` pointing to the original Freeze Tag page
+- Human QA can accept or reject this promotion
+
+Derived elements are clearly marked to distinguish them from elements that have dedicated source pages. Downstream, the graph can choose to include or exclude them.
+
+### Output
+
+`output/normalized/{source}.json` — same elements as the raw layer, augmented with structured fields and candidate sub-elements.
+
+## Layer 2: Knowledge Graph
+
+### Node Types
+
+| Node | What it represents | Example |
+|---|---|---|
+| `Element` | An improv structure (game, exercise, show form, concept) | "Freeze Tag", "Zip Zap Zop" |
+| `Mechanic` | A reusable building block / rule fragment | "freeze signal", "alphabet constraint" |
+| `Skill` | A competency trained by elements | "acceptance", "group mind", "character work" |
+| `Tag` | A canonical tag (existing flat system) | "warmup", "circle", "beginner" |
+| `Source` | Origin website | "improwiki.com", "learnimprov.com" |
+| `Category` | A dimension in the tag taxonomy | "Structure Type", "Grouping", "Difficulty" |
+
+### Edge Types
+
+| Edge | From → To | Source | Meaning |
+|---|---|---|---|
+| `translationOf` | Element ↔ Element | Scraped | DE/EN translation pair |
+| `sourcedFrom` | Element → Source | Scraped | Origin of this element |
+| `hasTag` | Element → Tag | Scraped + transformed | Element carries this tag |
+| `hasMechanic` | Element → Mechanic | LLM extraction | Uses this building block |
+| `variantOf` | Element → Element | LLM + heuristics | Y is a variation of X |
+| `trainsSkill` | Element → Skill | LLM extraction | Playing develops this skill |
+| `prerequisiteFor` | Element → Element | LLM extraction | Master X before Y |
+| `requiresSkill` | Element → Skill | LLM extraction | This skill is needed to play |
+| `similarTo` | Element ↔ Element | Computed | Share mechanics/tags |
+| `contrastsWith` | Element ↔ Element | Computed | Intentionally different |
+| `belongsTo` | Tag → Category | Manual taxonomy | Tag belongs to this dimension |
+| `derivedFrom` | Element → Element | Normalization | Sub-element extracted from parent page |
+
+### Derivation Steps
+
+1. **Heuristics** (deterministic): tag classification into taxonomy dimensions, naming-pattern variant detection, cross-source deduplication by name similarity, player count, translation links — all from existing scraped data.
+
+2. **LLM extraction** (one batch per element): mechanics list, skills list, variation relationships, prerequisite relationships, typical duration, energy level. Consumes normalized structured fields, not raw markdown.
+
+3. **Computed edges**: similarity (shared mechanics/tags), contrast (disjoint mechanics/tags), tag-to-category membership — derived mathematically from extracted data.
+
+### Output
+
+`output/graph.json` — nodes and edges array, serving as the single source of truth for the application layer.
+
+## Layer 2.5: Human QA
+
+Automated extraction will make mistakes. Misidentified mechanics, wrong variation links, missing prerequisites, incorrect energy levels.
+
+### Workflow
+
+1. LLM extraction produces `output/graph-draft.json`
+2. Human reviews draft edges and produces `output/graph-overrides.json` — a file containing only corrections: accepted edges, rejected edges, manually added edges
+3. Merge: draft + overrides → `output/graph.json`
+4. On re-scrape: for unchanged elements, overrides are preserved. Changed or new elements get re-extracted and flagged for review.
+
+The override file is diffable and can be tracked in git. The review interface starts as a flat file, evolvable to a web UI later.
+
+### Review Granularity
+
+Human QA operates at the **edge level** (accept/reject/add individual relationships), not at the element level. An element might have 15 edges, and the reviewer corrects 2 of them. The other 13 survive untouched.
+
+## Layer 3: Application
+
+Built on `output/graph.json`. Does not know about raw sources, scraping, or extraction.
+
+### Use Cases
+
+**Workshop Planner**: Given constraints (duration, player count, skill level, desired skills, theme), traverse the graph to generate a workshop sequence with:
+- Energy arc (medium → rising → peak → cool)
+- Skill scaffolding (each exercise builds on prerequisites from previous)
+- Variety constraints (avoid repeating grouping, mechanic, or energy level back-to-back)
+- Fallback alternatives (similarTo edges for "instead of X, try Y")
+
+**Show Set Builder**: Encode show formats as query templates over the graph. Suggest game combinations that fit format constraints. Ensure set list variety.
+
+**Element Browser**: Filter by mechanic, skill, tag, source, difficulty, player count. Navigate variation families. Compare elements across sources.
+
+### Implementation
+
+The application is a separate concern. It could be a CLI tool, a static site, or a web app — the graph is the contract. The interface type is deferred to a detailed application plan.
+
+## Phasing
+
+| Phase | What | Delivers | Depends On |
+|---|---|---|---|
+| P1 | Content normalization pipeline | `output/normalized/{source}.json` | Raw scrapers |
+| P2 | Knowledge graph derivation | `output/graph-draft.json` | P1 |
+| P3 | Human QA workflow | `output/graph-overrides.json` → `output/graph.json` | P2 |
+| P4 | Application: element browser | Filterable/searchable UI over the graph | P3 |
+| P5 | Application: workshop planner | Constraint-based sequence generation | P3 |
+| P6 | Application: show set builder | Format-aware set list generation | P3 |
+
+Each phase gets its own detailed plan in `docs/plans/`.
+
+## Data Dependency Graph
+
+```
+output/raw/improwiki.json ─┐
+output/raw/learnimprov.json ─┤
+output/raw/ircwiki.json ────┘
+        │
+        ▼
+output/normalized/improwiki.json ─┐
+output/normalized/learnimprov.json ─┤
+output/normalized/ircwiki.json ────┘
+        │
+        ▼
+output/graph-draft.json  ──(+ overrides)──▶  output/graph.json
+        │                                            │
+        ▼                                            ▼
+   Human QA                                   Application
+```
+
+## Open Questions
+
+1. **LLM model**: Local (Ollama) vs API (Claude, GPT)? Content normalization + graph extraction is a one-time batch per element (~500–1000 elements). API cost is modest even with larger models.
+
+2. **Derived sub-elements**: Should inline variations be promoted to first-class element nodes (with `derivedFrom` edges), or kept as structured data on the parent? _Current lean: promote, clearly marked, with human QA approval._
+
+3. **Language handling**: The graph has DE and EN elements connected by `translationOf`. Should mechanics and skills be language-agnostic concepts, or language-specific? _Current lean: language-agnostic — a mechanic is a concept, not a string._
+
+4. **Graph format**: JSON array of nodes + edges. Could consider JSON-LD or RDF for standards compatibility. Tradeoff: simplicity vs. interoperability.
+
+5. **External sequencing data**: Should the graph also ingest existing workshop curricula or show setlists (from books, blogs, YouTube) to mine sequencing edges? _Deferred to a future phase._
+
+6. **Re-scrape behavior**: When sources are re-scraped, how do we handle elements that changed? _New/changed elements get re-normalized and re-extracted. Unchanged elements keep their reviewed graph edges. The change detection uses the existing MD5 identifier._
+
+## Key Design Principles
+
+- **Raw is immutable**: Original source content is never modified. Normalization and graph derivation are additive.
+- **Layers are independent**: Each layer produces a file artifact. Downstream layers can be iterated without re-running upstream.
+- **Human QA is a separate artifact**: Review decisions live in their own file. They survive re-scrapes and re-extraction.
+- **The graph is the contract**: The application consumes only `graph.json`. Nothing leaks through from sources or scraping.
+- **Derived elements are marked**: Any element not backed by its own source page is clearly distinguished from scraped elements.

--- a/docs/plans/0001-knowledge-graph-and-application.md
+++ b/docs/plans/0001-knowledge-graph-and-application.md
@@ -44,39 +44,73 @@ Scrapes source websites, extracts metadata and raw HTML, resolves cross-page lin
 
 This layer is already built. Existing ADRs document the decisions.
 
-## Layer 1.5: Content Normalization
+## Layer 1.5: Content Normalization ✅ Implemented
+
+See [ADR-0008](../adrs/0008-normalization-layer.md) for detailed decisions.
 
 ### Problem
 
-Source content is inconsistently structured. A single page may contain a game description, inline variations, tips, cross-references to other games, and pedagogical notes — all as unstructured markdown. Feeding this directly into graph derivation produces unreliable extraction.
+Source content is inconsistently structured. A single page may contain a game description, inline variations, tips, cross-references to other games, and pedagogical notes — all as unstructured HTML. Feeding this directly into graph derivation produces unreliable extraction.
 
-### What it does
+### Pipeline
 
-For each element, an LLM pass structures the raw markdown into clean fields:
+```
+output/raw/{source}.json
+  │
+  ▼
+turndown (HTML → markdown)
+  │
+  ▼
+LLM extraction (opencode-go/deepseek-v4-flash via CLI)
+  │
+  ▼
+Zod validation → NormalizedElement
+  │
+  ▼
+output/normalized/{source}.json
+```
+
+### Extracted fields
 
 | Field | Content |
 |---|---|
 | `description` | 1–3 sentence summary of what the element is |
-| `howToPlay` | Step-by-step instructions |
+| `howToPlay` | Numbered step-by-step instructions, or `null` for theory/concepts |
 | `variations` | Named variations described inline, with their own short descriptions |
 | `tips` | Pedagogical notes, common pitfalls, teacher advice |
 | `referencedElements` | Names of other elements mentioned in the text |
 
-The original markdown is preserved unchanged. The structured fields augment it.
+The original HTML is preserved unchanged (`htmlContent`). The structured fields augment it under `normalized`.
 
-### Inline variations → candidate sub-elements
+### Quality assurance: golden test set
 
-When a source page describes a variation that has no dedicated page of its own, normalization promotes it to a **derived sub-element**. Example:
+A 15-element test set (`src/normalize/__testdata__/golden-set.ts`) covers edge cases across all three sources and both languages. Each entry has a hand-verified `expectedOutput` serving as ground truth. A benchmark runner (`run-benchmark.ts`) compares model outputs against these expectations.
 
-- Source page: "Freeze Tag" describes "Emotional Freeze Tag" as a one-paragraph variation
-- Normalization output: `Emotional Freeze Tag` becomes a candidate element with `derivedFrom: "Freeze Tag"` and `sourcedFrom` pointing to the original Freeze Tag page
-- Human QA can accept or reject this promotion
+Benchmark results (opencode 1.15.5):
 
-Derived elements are clearly marked to distinguish them from elements that have dedicated source pages. Downstream, the graph can choose to include or exclude them.
+| Model | Overall | Description | howToPlay | Var Recall | Tip Recall |
+|-------|---------|-------------|-----------|------------|------------|
+| deepseek-v4-pro | 93% | 100% | 100% | 93% | 71% |
+| deepseek-v4-flash | 91% | 100% | 100% | 100% | 51% |
+
+### Change detection
+
+Each normalized element stores `contentHash = md5(htmlContent)`. On re-normalization, elements whose hash matches the previous run are preserved unchanged. New or modified elements trigger a fresh LLM call.
+
+### Inline variations → derived sub-elements
+
+Variations described in the parent page with substantial descriptions (>40 chars) are promoted to `derivedElements`. These are clearly marked — they lack dedicated source pages. The graph layer can choose to include or exclude them.
+
+### Cross-source hints
+
+After normalizing all sources, a token-overlap name matcher (`cross-source-matching.ts`) computes `relatedIdentifiers` — elements from different sources that likely refer to the same game/exercise. This is a hint, not a merge. The actual deduplication decision belongs to the graph layer.
 
 ### Output
 
-`output/normalized/{source}.json` — same elements as the raw layer, augmented with structured fields and candidate sub-elements.
+`output/normalized/{source}.json` — all raw fields preserved, augmented with:
+- `normalized` (description, howToPlay, variations, tips, referencedElements, contentHash, extractedAt)
+- `derivedElements` (candidate sub-elements from inline variations)
+- `relatedIdentifiers` (cross-source match hints)
 
 ## Layer 2: Knowledge Graph
 
@@ -110,7 +144,7 @@ Derived elements are clearly marked to distinguish them from elements that have 
 
 ### Derivation Steps
 
-1. **Heuristics** (deterministic): tag classification into taxonomy dimensions, naming-pattern variant detection, cross-source deduplication by name similarity, player count, translation links — all from existing scraped data.
+1. **Heuristics** (deterministic): tag classification into taxonomy dimensions, naming-pattern variant detection, cross-source deduplication by name similarity (using `relatedIdentifiers` from Layer 1.5 as starting points), player count, translation links — all from existing normalized data.
 
 2. **LLM extraction** (one batch per element): mechanics list, skills list, variation relationships, prerequisite relationships, typical duration, energy level. Consumes normalized structured fields, not raw markdown.
 
@@ -191,9 +225,9 @@ output/graph-draft.json  ──(+ overrides)──▶  output/graph.json
 
 ## Open Questions
 
-1. **LLM model**: Local (Ollama) vs API (Claude, GPT)? Content normalization + graph extraction is a one-time batch per element (~500–1000 elements). API cost is modest even with larger models.
+1. **LLM model**: ~~Local (Ollama) vs API (Claude, GPT)?~~ Resolved: using opencode-go/deepseek-v4-flash via CLI (free on OpenCode Go plan, no additional API keys needed). Pro model kept as benchmark reference.
 
-2. **Derived sub-elements**: Should inline variations be promoted to first-class element nodes (with `derivedFrom` edges), or kept as structured data on the parent? _Current lean: promote, clearly marked, with human QA approval._
+2. **Derived sub-elements**: Should inline variations be promoted to first-class element nodes (with `derivedFrom` edges), or kept as structured data on the parent? _Promoted, clearly marked in `derivedElements`. Graph layer decides whether to include them._
 
 3. **Language handling**: The graph has DE and EN elements connected by `translationOf`. Should mechanics and skills be language-agnostic concepts, or language-specific? _Current lean: language-agnostic — a mechanic is a concept, not a string._
 
@@ -201,7 +235,7 @@ output/graph-draft.json  ──(+ overrides)──▶  output/graph.json
 
 5. **External sequencing data**: Should the graph also ingest existing workshop curricula or show setlists (from books, blogs, YouTube) to mine sequencing edges? _Deferred to a future phase._
 
-6. **Re-scrape behavior**: When sources are re-scraped, how do we handle elements that changed? _New/changed elements get re-normalized and re-extracted. Unchanged elements keep their reviewed graph edges. The change detection uses the existing MD5 identifier._
+6. **Re-scrape behavior**: When sources are re-scraped, how do we handle elements that changed? _New/changed elements get re-normalized and re-extracted. Unchanged elements keep their reviewed graph edges. The change detection uses `contentHash = md5(htmlContent)` from Layer 1.5._
 
 ## Key Design Principles
 

--- a/src/fetch-raw.ts
+++ b/src/fetch-raw.ts
@@ -1,0 +1,27 @@
+import path from "path";
+
+const BASE_URL = "https://improbib.host.impromat.app/raw";
+const SOURCES = ["improwiki", "learnimprov", "ircwiki"] as const;
+
+async function main() {
+  const outDir = path.join(process.cwd(), "output", "raw");
+  await Bun.$`mkdir -p ${outDir}`.quiet();
+
+  for (const source of SOURCES) {
+    const url = `${BASE_URL}/${source}.json`;
+    console.log(`Fetching ${url}...`);
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      console.error(`  Failed: ${resp.status} ${resp.statusText}`);
+      continue;
+    }
+    const data = await resp.json();
+    const count = data.elements?.length ?? 0;
+    const outPath = path.join(outDir, `${source}.json`);
+    await Bun.write(outPath, JSON.stringify(data, null, 2));
+    console.log(`  Wrote ${outPath} (${count} elements)`);
+  }
+  console.log("Done.");
+}
+
+main().catch(console.error);

--- a/src/normalize/__testdata__/cross-source-matching.test.ts
+++ b/src/normalize/__testdata__/cross-source-matching.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import {
+  findCrossSourceMatches,
+  buildRelatedIdentifiers,
+  type MatchCandidate,
+} from "../cross-source-matching";
+
+const makeCandidate = (
+  id: string,
+  name: string,
+  source: string,
+  lang = "en",
+): MatchCandidate => ({
+  identifier: id,
+  name,
+  sourceName: source,
+  languageCode: lang,
+});
+
+describe("cross-source-matching", () => {
+  it("matches identical names across sources", () => {
+    const matches = findCrossSourceMatches([
+      makeCandidate("a1", "Freeze Tag", "improwiki"),
+      makeCandidate("b1", "Freeze Tag", "learnimprov"),
+      makeCandidate("c1", "Unrelated Game", "improwiki"),
+    ]);
+
+    expect(matches.length).toBe(1);
+    expect(matches[0].score).toBe(1.0);
+    expect(matches[0].a.identifier).toBe("a1");
+    expect(matches[0].b.identifier).toBe("b1");
+  });
+
+  it("does not match within same source", () => {
+    const matches = findCrossSourceMatches([
+      makeCandidate("a1", "Freeze Tag", "improwiki"),
+      makeCandidate("a2", "Freeze Tag", "improwiki"),
+    ]);
+
+    expect(matches.length).toBe(0);
+  });
+
+  it("matches similar names with token overlap", () => {
+    const matches = findCrossSourceMatches([
+      makeCandidate("a1", "Translation Healthcare", "improwiki"),
+      makeCandidate("b1", "Healthcare Translation", "learnimprov"),
+    ]);
+
+    expect(matches.length).toBe(1);
+    expect(matches[0].score).toBeGreaterThan(0.8);
+  });
+
+  it("matches ignoring punctuation and case", () => {
+    const matches = findCrossSourceMatches([
+      makeCandidate("a1", "Yes - No", "improwiki"),
+      makeCandidate("b1", "Yes No", "learnimprov"),
+    ]);
+
+    expect(matches.length).toBe(1);
+    expect(matches[0].score).toBeGreaterThan(0.8);
+  });
+
+  it("does not match unrelated names", () => {
+    const matches = findCrossSourceMatches([
+      makeCandidate("a1", "Freeze Tag", "improwiki"),
+      makeCandidate("b1", "Counting Circle", "learnimprov"),
+    ]);
+
+    expect(matches.length).toBe(0);
+  });
+
+  it("matches German and English versions of the same game", () => {
+    const matches = findCrossSourceMatches([
+      makeCandidate("a1", "Freeze Tag", "improwiki", "en"),
+      makeCandidate("b1", "Freeze Tag", "learnimprov", "en"),
+      makeCandidate("c1", "Gefühlspunkte", "improwiki", "de"),
+      makeCandidate("d1", "Unrelated", "learnimprov", "en"),
+    ]);
+
+    expect(matches.length).toBe(1);
+    expect(matches[0].a.name).toBe("Freeze Tag");
+  });
+
+  it("buildRelatedIdentifiers returns correct map", () => {
+    const related = buildRelatedIdentifiers([
+      makeCandidate("a1", "Freeze Tag", "improwiki"),
+      makeCandidate("b1", "Freeze Tag", "learnimprov"),
+      makeCandidate("c1", "Translation Healthcare", "improwiki"),
+      makeCandidate("d1", "Healthcare Translation", "learnimprov"),
+      makeCandidate("e1", "Unique Game", "ircwiki"),
+    ]);
+
+    expect(related.get("a1")).toContain("b1");
+    expect(related.get("b1")).toContain("a1");
+    expect(related.get("c1")).toContain("d1");
+    expect(related.get("d1")).toContain("c1");
+    expect(related.get("e1")).toBeUndefined();
+  });
+});

--- a/src/normalize/__testdata__/golden-set.test.ts
+++ b/src/normalize/__testdata__/golden-set.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "bun:test";
+import TurndownService from "turndown";
+import { goldenSet } from "./golden-set";
+import type { GoldenEntry, GoldenOutput } from "./golden-set";
+
+const turndown = new TurndownService({ headingStyle: "atx" });
+
+/**
+ * Converts HTML content to markdown using the same turndown config
+ * as the main pipeline (src/scraping/shared/process-markdown.ts)
+ */
+function htmlToMarkdown(html: string): string {
+  return turndown.turndown(html).trim();
+}
+
+/**
+ * The normalization function that any LLM-backed implementation
+ * should replicate. In tests, this is replaced with a mock or
+ * actual LLM call. The expected outputs in golden-set.ts are
+ * the ground truth.
+ */
+export type NormalizeFn = (entry: GoldenEntry) => Promise<GoldenOutput>;
+
+// ── Structural validations on the golden set itself ──
+
+describe("golden set integrity", () => {
+  it("contains exactly 15 test cases", () => {
+    expect(goldenSet.length).toBe(15);
+  });
+
+  it("all entries have unique IDs", () => {
+    const ids = goldenSet.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("all categories are represented", () => {
+    const categories = new Set(goldenSet.map((e) => e.category));
+    expect(categories.size).toBeGreaterThanOrEqual(7);
+  });
+
+  it("all expected outputs have valid description", () => {
+    for (const entry of goldenSet) {
+      expect(entry.expectedOutput.description.length).toBeGreaterThanOrEqual(20);
+      expect(entry.expectedOutput.description).toBeTruthy();
+    }
+  });
+
+  it("howToPlay is null for concept pages, non-null for games/exercises", () => {
+    for (const entry of goldenSet) {
+      if (entry.id === "game-concept" || entry.id === "what-did-you-want") {
+        expect(entry.expectedOutput.howToPlay).toBeNull();
+      } else {
+        expect(entry.expectedOutput.howToPlay).toBeTruthy();
+        expect((entry.expectedOutput.howToPlay as string).length).toBeGreaterThan(10);
+      }
+    }
+  });
+
+  it("covers all 3 source types", () => {
+    const sources = new Set(goldenSet.map((e) => e.input.sourceName));
+    expect(sources.has("improwiki")).toBeTrue();
+    expect(sources.has("learnimprov")).toBeTrue();
+    expect(sources.has("ircwiki")).toBeTrue();
+  });
+
+  it("includes both English and German content", () => {
+    const langs = new Set(goldenSet.map((e) => e.input.languageCode));
+    expect(langs.has("en")).toBeTrue();
+    expect(langs.has("de")).toBeTrue();
+  });
+
+  it("includes edge case: minimal html content (< 100 chars)", () => {
+    const minimal = goldenSet.filter((e) => e.input.htmlContent.length < 100);
+    expect(minimal.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("includes edge case: very long html content (> 2000 chars)", () => {
+    const long = goldenSet.filter((e) => e.input.htmlContent.length > 2000);
+    expect(long.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("includes edge case: empty tags array", () => {
+    const emptyTags = goldenSet.filter((e) => e.input.tags.length === 0);
+    expect(emptyTags.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("all inputs convert to valid markdown via turndown", () => {
+    for (const entry of goldenSet) {
+      const md = htmlToMarkdown(entry.input.htmlContent);
+      expect(typeof md).toBe("string");
+      // The ask-for edge case has blank htmlContent — markdown will be empty
+      if (entry.id !== "what-did-you-want") {
+        expect(md.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("all entries have at least one expected output field populated", () => {
+    for (const entry of goldenSet) {
+      const o = entry.expectedOutput;
+      const hasContent =
+        o.description.length > 0 ||
+        o.howToPlay !== null ||
+        o.variations.length > 0 ||
+        o.tips.length > 0;
+      expect(hasContent).toBeTrue();
+    }
+  });
+
+  it("referencedElements contains plausible game names when present", () => {
+    for (const entry of goldenSet) {
+      for (const ref of entry.expectedOutput.referencedElements) {
+        // Referenced element names should be plain text, not URLs
+        expect(ref).not.toContain("http");
+        expect(ref).not.toContain("/");
+        expect(ref.length).toBeGreaterThan(1);
+      }
+    }
+  });
+});
+
+// ── Model comparison harness ──
+
+/**
+ * Run the given normalize function against all golden elements
+ * and return per-element results with diff information.
+ *
+ * Usage:
+ *   import { runGoldenBenchmark } from "./golden-set.test";
+ *   const results = await runGoldenBenchmark(myNormalizeFn);
+ */
+export async function runGoldenBenchmark(
+  normalize: NormalizeFn,
+): Promise<
+  {
+    id: string;
+    category: string;
+    name: string;
+    passed: boolean;
+    failures: string[];
+    output: GoldenOutput;
+  }[]
+> {
+  const results = [];
+  for (const entry of goldenSet) {
+    const output = await normalize(entry);
+    const failures: string[] = [];
+
+    // Check description exists and is non-trivial
+    if (!output.description || output.description.length < 10) {
+      failures.push("description too short or missing");
+    }
+
+    // Check howToPlay consistency
+    if (entry.expectedOutput.howToPlay === null && output.howToPlay !== null) {
+      failures.push("howToPlay should be null but got a value");
+    }
+    if (entry.expectedOutput.howToPlay !== null && output.howToPlay === null) {
+      failures.push("howToPlay should have a value but got null");
+    }
+
+    // Check variation count is reasonable
+    if (
+      Math.abs(
+        output.variations.length - entry.expectedOutput.variations.length,
+      ) > 3
+    ) {
+      failures.push(
+        `variation count mismatch: expected ${entry.expectedOutput.variations.length}, got ${output.variations.length}`,
+      );
+    }
+
+    results.push({
+      id: entry.id,
+      category: entry.category,
+      name: entry.input.name,
+      passed: failures.length === 0,
+      failures,
+      output,
+    });
+  }
+  return results;
+}
+
+// ── Snapshot-like reference test (skipped by default) ──
+
+/**
+ * This test is marked as TODO because it requires an actual LLM to run.
+ * It serves as documentation of how to validate a normalization implementation
+ * against the golden set.
+ *
+ * To use with a real LLM:
+ *   const normalize = async (entry: GoldenEntry): Promise<GoldenOutput> => {
+ *     const markdown = htmlToMarkdown(entry.input.htmlContent);
+ *     const prompt = buildExtractionPrompt(entry.input.name, markdown, entry.input.languageCode);
+ *     const result = await callLlm(prompt); // your LLM client
+ *     return result;
+ *   };
+ *   const results = await runGoldenBenchmark(normalize);
+ *   console.table(results);
+ */
+describe.skip("llm extraction vs golden set", () => {
+  it("all 15 elements extract correctly", async () => {
+    // Placeholder — replace with actual LLM call
+    const normalize: NormalizeFn = async (entry) => {
+      throw new Error(
+        `Not implemented: plug in your LLM client for ${entry.id}`,
+      );
+    };
+
+    const results = await runGoldenBenchmark(normalize);
+    const failures = results.filter((r) => !r.passed);
+    if (failures.length > 0) {
+      console.table(
+        failures.map((f) => ({
+          id: f.id,
+          category: f.category,
+          failures: f.failures.join("; "),
+        })),
+      );
+    }
+    expect(failures.length).toBe(0);
+  });
+});

--- a/src/normalize/__testdata__/golden-set.ts
+++ b/src/normalize/__testdata__/golden-set.ts
@@ -1,0 +1,613 @@
+export interface GoldenInput {
+  name: string;
+  htmlContent: string;
+  languageCode: string;
+  sourceName: string;
+  tags: string[];
+}
+
+export interface GoldenOutput {
+  description: string;
+  howToPlay: string | null;
+  variations: { name: string; description: string }[];
+  tips: string[];
+  referencedElements: string[];
+}
+
+export interface GoldenEntry {
+  id: string;
+  category: string;
+  input: GoldenInput;
+  expectedOutput: GoldenOutput;
+}
+
+export const goldenSet: GoldenEntry[] = [
+  // ── Category: well-structured-game ──
+  {
+    id: "freeze-tag",
+    category: "well-structured-game",
+    input: {
+      name: "Freeze Tag",
+      languageCode: "en",
+      sourceName: "improwiki",
+      tags: ["Switches", "Chain Games", "game"],
+      htmlContent: `
+<h2>Freeze Tag: When the picture stands still and everything starts over</h2>
+
+<p>The Freeze Tag game is basically adrenaline turned into an art form. It's the absolute classic among improv games for channelling stage fright straight into creative energy. You'll also hear it called "Freeze", "Zap", "Chain Impro" or "Tap Out". It's the perfect warm-up for any group, but thanks to its speed and high entertainment value, Freeze Tag works just as brilliantly as a stand-alone act on the big stage.</p>
+
+<p>At its core, the game is about stealing a random, frozen body posture and breathing new life into it in a completely different scene with a completely different meaning. It's the ultimate training ground for the most important rule in improv: the "yes, and". You accept the physical reality your scene partners give you and add your own fresh world to it.</p>
+
+<h3>How to play the Freeze Tag game</h3>
+
+<p>The setup is dead simple. All players in the group stand at the edge of the stage or in the background, ready to go. Two players step into the spotlight and start a scene with full physical commitment. It's important that they don't just chat with each other but use the space, move around, do things and stay physically present.</p>
+
+<p>After a short while someone calls "STOP!" or "FREEZE!" loudly, either from off-stage or from one of the waiting players. In that exact moment, the actors on stage have to freeze instantly in their current position, like a statue. Every gesture, every bent knee, every raised arm stays absolutely still.</p>
+
+<p>Now a new player enters from the side. They pick one of the frozen colleagues, gently tap them out and take over that exact pose. The tagged-out player leaves the stage. The new player immediately begins a completely new scene. This scene is inspired purely by the physical posture and is allowed to have absolutely nothing to do with the previous storyline.</p>
+
+<ol>
+<li>Set up. All players form a loose half-circle at the edge of the stage. Two players step out and begin a scene with full physical commitment.</li>
+<li>Play the scene. The two players move, use the space and react to each other. No "talking heads".</li>
+<li>Call the freeze. Any waiting player can shout "Freeze!" or "Stop!" when the picture on stage is strong or interesting.</li>
+<li>Hold the picture. Both stage players freeze instantly in their exact poses. No drift, no relaxation.</li>
+<li>Tag and take over. A waiting player walks on, gently taps out one of the frozen players and takes over that exact pose.</li>
+<li>Start a brand-new scene. The new player justifies the pose with a completely fresh scene. Story, setting and characters have nothing to do with what came before.</li>
+</ol>
+
+<p>Repeat until you run out of breath, ideas or energy. The game ends when the group decides. There's no formal win condition unless you play the Elimination Freeze variant.</p>
+
+<h3>Exciting variations for training</h3>
+
+<ul>
+<li>Blind Freeze: The waiting players stand with their back to the stage. Whoever feels the time is right calls "stop", turns around and has to work with whatever picture they find. That stops people from preparing a scene minutes in advance and pushes pure spontaneity.</li>
+<li>Elimination Freeze: This is the competitive version. Anyone who lacks a quick idea, hesitates too long or stalls in the justification is out. At the end one "freeze king" is left. That ramps up the pressure and works especially well in shows.</li>
+<li>Object Freeze: Here the focus is on the pose always involving the interaction with an invisible object. Every new scene therefore has to define an object that's being held or moved by the body posture.</li>
+</ul>
+
+<h3>Pro tips for more depth and quality</h3>
+
+<p>1. Avoid the obvious continuation. If someone is frozen with a raised arm, the policeman directing traffic is the first idea every player has. Try to take a step further.</p>
+<p>2. Give extreme poses as gifts. Putting yourself in uncomfortable or dynamic positions is a wonderful gift to your colleagues.</p>
+<p>3. The timing of the freeze. A good freeze hits when the picture is especially strong or when a conflict has just reached its peak. Whoever interrupts too early cuts off an interesting development.</p>
+<p>4. Watch carefully. Whoever stands at the side of the stage shouldn't only be thinking about their own next idea. You have to watch closely how your colleagues' poses look.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Freeze Tag is a fast-paced improv game where two players start a scene, anyone calls \"Freeze!\" to lock them in position, and a new player taps in, assumes the frozen pose, and launches an entirely new, unrelated scene. It trains spontaneity, physicality, and the core improv principle of accepting what you are given and building on it. Also known as \"Freeze\", \"Zap\", \"Chain Impro\" or \"Tap Out\".",
+      howToPlay:
+        "1. Two players begin a scene with full physical commitment — moving, using the space, no \"talking heads\".\n2. Any waiting player shouts \"Freeze!\" or \"Stop!\" when the stage picture is strong or interesting.\n3. Both stage players freeze instantly in their exact poses — no drift, no relaxation.\n4. A waiting player steps forward, gently taps out one frozen player, and takes over that exact pose. The tapped-out player leaves the stage.\n5. The new player immediately begins a completely new scene, justifying the pose with fresh characters, setting, and story — totally unrelated to the previous scene.\n6. Repeat until the group decides to end.",
+      variations: [
+        {
+          name: "Blind Freeze",
+          description:
+            "Waiting players stand with their backs to the stage. They call \"stop\", turn around, and must work with whatever picture they find. Prevents pre-planning and pushes pure spontaneity.",
+        },
+        {
+          name: "Elimination Freeze",
+          description:
+            "Competitive version. Players who hesitate, lack ideas, or stall in justification are eliminated. The last remaining player is the \"freeze king\". Works especially well in shows.",
+        },
+        {
+          name: "Object Freeze",
+          description:
+            "Poses must involve interaction with an invisible object. Every new scene defines what object is being held or manipulated by the body posture.",
+        },
+      ],
+      tips: [
+        "Avoid the obvious continuation — a raised arm doesn't always have to be a traffic cop. Take the idea one step further.",
+        "Give extreme and dynamic poses as gifts when you are on stage. Static standing offers no inspiration to the next player.",
+        "Time the freeze when the stage picture is especially strong or a conflict has just peaked — not too early, not too late.",
+        "Watch colleagues' poses carefully from the sideline. Inaccurate pose reproduction leads to a wooden new scene start.",
+      ],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: inline-variant ──
+  {
+    id: "half-life",
+    category: "inline-variant",
+    input: {
+      name: "Half-Life",
+      languageCode: "en",
+      sourceName: "improwiki",
+      tags: [],
+      htmlContent: `
+<p>Also known as Fast Forward</p>
+<p>A scene is played within one minute and is then repeated in the given time frames of 30, 15, 7, 3 seconds and finally 1 second.</p>
+<p>This shortening forces the players to reduce themselves more and more to the essentials of the scene. As a rule, even a weak starting scene turns into a guaranteed laugh thanks to the slapstick effect of the compressions.</p>
+<h2>Tips and notes</h2>
+<ul>
+<li>It helps to ask the audience for a suggestion based on a dramatic situation.</li>
+<li>The starting scene should contain as much action as possible: changes of location, dialogue, drama and so on.</li>
+<li>It is important to always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats. And of course the audience enjoys watching the players struggle, race against the clock and end up completely out of breath.</li>
+</ul>
+<p>Variant: The starting scene can have any length, and the first compression then cuts it down to one minute.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Half-Life (also known as Fast Forward) is an improv game where a scene is first played in one minute, then repeated in ever-shorter time frames — 30, 15, 7, 3, and finally 1 second. The rapid compression forces players to strip each repetition down to the essential beats, and the resulting slapstick effect reliably generates laughs even from weak starting material.",
+      howToPlay:
+        "1. Ask the audience for a dramatic situation to start the scene.\n2. Play a scene with as much action as possible — location changes, dialogue, drama.\n3. After one minute, repeat the same scene in 30 seconds, hitting all the key anchor points.\n4. Repeat again in 15 seconds, then 7, then 3, then 1 second, each time compressing to the essentials.",
+      variations: [
+        {
+          name: "Variable Start Length",
+          description:
+            "The starting scene can have any length, and the first compression then cuts it down to one minute.",
+        },
+      ],
+      tips: [
+        "Ask the audience for a suggestion based on a dramatic situation — it gives the scene stakes from the start.",
+        "The starting scene should contain as much action as possible: changes of location, dialogue, drama — the more material, the funnier the compressions.",
+        "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats.",
+      ],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: minimal-content ──
+  {
+    id: "yes-no",
+    category: "minimal-content",
+    input: {
+      name: "Yes - No",
+      languageCode: "en",
+      sourceName: "improwiki",
+      tags: ["Improv Exercises", "Expression", "exercise"],
+      htmlContent: `
+<p>Players form pairs. One can only say 'Yes', the other only 'No'. Despite this limitation, they have a full conversation using tone, volume, rhythm, pauses, and body language.</p>
+<p>After a while, roles switch. This trains vocal expression, status play, and the realization that communication is mostly non-verbal.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Yes - No is a simple paired improv exercise where one player can only say \"Yes\" and the other only \"No\". Despite having just one word each, they carry out a full conversation using tone, volume, rhythm, pauses, and body language. Roles are swapped partway through.",
+      howToPlay:
+        "1. Form pairs. One player may only say \"Yes\", the other only \"No\".\n2. Have a full conversation despite the limitation, using tone, volume, rhythm, pauses, and body language to convey meaning.\n3. After a while, switch roles so each player experiences both constraints.",
+      variations: [],
+      tips: [
+        "Communication is mostly non-verbal — this exercise makes that vivid by restricting vocabulary to a single word each.",
+        "Use tone, volume, rhythm, and pauses to differentiate between question, statement, anger, excitement, and other meanings.",
+      ],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: short-exercise ──
+  {
+    id: "mirror-exercises",
+    category: "short-exercise",
+    input: {
+      name: "Mirror Exercises",
+      languageCode: "en",
+      sourceName: "improwiki",
+      tags: ["Improv Exercises"],
+      htmlContent: `
+<p>Two players face each other. One leads with slow movements, the other mirrors exactly. The goal is for an observer to not be able to tell who leads.</p>
+<p>After a while, switch roles. Eventually, try leading and following simultaneously — no designated leader.</p>
+<p>This classic exercise trains observation, patience, and physical synchronization.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Mirror Exercises is a classic paired improv warm-up where two players face each other and one mirrors the other's slow movements exactly. The goal is for an outside observer to be unable to tell who is leading and who is following. It trains observation, patience, and physical synchronization.",
+      howToPlay:
+        "1. Two players face each other. One leads with slow, deliberate movements while the other mirrors exactly.\n2. The goal is for an observer to not be able to tell who leads.\n3. Switch roles after a while.\n4. Eventually, try leading and following simultaneously with no designated leader.",
+      variations: [],
+      tips: [],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: medium-game ──
+  {
+    id: "talk-at-touch",
+    category: "medium-game",
+    input: {
+      name: "Talk at touch",
+      languageCode: "en",
+      sourceName: "improwiki",
+      tags: ["Physical Contact", "game"],
+      htmlContent: `
+<p>A scene is played by two players, if necessary with input from the audience.</p>
+<p>However, it is only allowed to speak if one player touches the other and then only the person who makes the touch is allowed to speak. Permanent contact such as holding hands is prohibited.</p>
+<p>This leads to a change from mute to spoken sections. The comedy arises from the necessity of the players to touch each other somewhere in order to be able to tell him something.</p>
+<p>Variant: A touch is always valid in both directions, i.e. as soon as the contact is there, both may speak, no matter who gave the touch. As soon as the contact breaks off, both have to be silent again and can only play pantomime.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Talk at touch is a two-player improv game where speaking is only allowed while one player is physically touching the other, and only the player who initiated the touch may talk. Permanent contact like holding hands is prohibited. The constant alternation between mute physical play and spoken sections creates comedy from the necessity to touch in order to communicate.",
+      howToPlay:
+        "1. Two players perform a scene, optionally with an audience suggestion.\n2. A player may only speak while touching the other player, and only the touching player may talk.\n3. Permanent contact such as holding hands is prohibited — touch must be initiated anew each time.\n4. This produces a rhythm of mute physical sections alternating with spoken dialogue.",
+      variations: [
+        {
+          name: "Bidirectional Touch",
+          description:
+            "A touch is valid in both directions: as soon as contact exists, both players may speak regardless of who initiated it. When contact breaks, both must be silent and can only play pantomime.",
+        },
+      ],
+      tips: [],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: external-refs ──
+  {
+    id: "swinging-pendulum",
+    category: "external-refs",
+    input: {
+      name: "Swinging Pendulum of Death",
+      languageCode: "en",
+      sourceName: "improwiki",
+      tags: ["Improv Games"],
+      htmlContent: `
+<h3>Actors</h3>
+<p>3</p>
+<h3>Suggestions</h3>
+<p>3 locations, 3 conflicts, 3 characters</p>
+<h3>Premise</h3>
+<p>This game is complicated but can be extremely entertaining if done well. It is therefore presented in step-by-step instructions.</p>
+<ol>
+<li>Each actor is given a location, conflict, and character</li>
+<li>For our example we'll use a car salesman trying to sell cars to blind people in a mall, a half-man/half-duck trying to get a job at a supermarket, and an ex-ballerina with an addiction to smelling grass at a grass-smellers anonymous meeting. Got all that?</li>
+<li>The game will start at the mall. The only given character is the car salesman, so of course the other two will be blind. They must build up the scene to the point that the salesman dies.</li>
+<li>The judge will then call out one of the other two locations, say the supermarket. The salesman will "come back to life" as a new character within the new location, perhaps the manger interviewing the duck/man. The third actor might act as a current employee with an unnatural fear of ducks. Again, the scene must be advanced to the point that the duck/man dies.</li>
+<li>Rinse and repeat for the third location. Duck/man comes to life as a different character in this location, and the scene is advanced until the ex-ballerina dies.</li>
+<li>After the three deaths are established, the judge will call any one of the locations at random, and the actor who died in that location must immediately drop dead, and the other actors must pick up where the scene left off, dealing with the aftermath of the death. This will be repeated until the buzzer signals the end of the game.</li>
+</ol>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Swinging Pendulum of Death is a complex three-player improv game with strong narrative structure. Each player is given a distinct character, location, and conflict. The game cycles through three locations, with one character dying at each, then repeatedly revisits locations at random — requiring the actor who died there to drop dead instantly while the others deal with the aftermath.",
+      howToPlay:
+        "1. Assign each of three actors a location, a conflict, and a character.\n2. Start at the first actor's location. The other two adapt to fit that scenario. Play the scene until that actor's character dies.\n3. The judge calls a new location. The actor who just died returns as a new character. Play the scene until the second actor's character dies.\n4. Repeat for the third location until the third character dies.\n5. Once all three deaths are established, the judge calls locations at random. The actor who died in that location immediately drops dead, and the others continue the aftermath. Repeat until the game ends.",
+      variations: [],
+      tips: [],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: long-form-show ──
+  {
+    id: "superscene",
+    category: "long-form-show",
+    input: {
+      name: "Superscene",
+      languageCode: "en",
+      sourceName: "improwiki",
+      tags: ["Improv Forms", "Improv Games", "Long Forms", "show", "longform"],
+      htmlContent: `
+<p>Three to five people can take part in this game. Each of the players is responsible for one of the stories, as its director. He introduces the scene, asks the audience about the guidelines, and can -- if he wants -- place any further requirements, e.g., deciding on the form of his game (e.g., rhyme, ABC-game, genre). The other players now perform the scene. At a given time, the director ends the scene. Then it is the next player's turn, taking on the role of director. He also introduces the scene and creates the guidelines, etc, then it also gets played. It continues this way until all three to five players have directed one time.</p>
+<p>After that the round of the game is over. The scenes which were performed are each briefly outlined and promoted by the directors, who make it clear why the audience should definitely see its sequel. The audience now decides which story they would like to see more of. Each scene performed is voted upon by applause. The scene with the least applause falls out.</p>
+<p>The second round begins. Each of the individuals who directed one of the stories to be continued receive additional guidelines from the audience, and in addition the players can make further suggestions. The rest of this round goes like the first, but just without the play which was eliminated. Also after this round, one play is rejected. At the end, one story remains, the "Superscene", the story which the audience collectively found most interesting.</p>
+<p>Hints and Tips:</p>
+<p>The directors only promote their own story, they will not comment on or disparage the others. It is all about arousing and maintaining the interest of the audience in the progress of the story. It is sensible to end each scene with a cliff-hanger. The director does not cut off the continuing scene by the rules any more. It is about creative cooperation, i.e. even when the directors (supposedly) are competitors, all still try to give their best in every scene.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Superscene is a long-form improv show format for three to five players, structured as a competitive storytelling tournament. Each player acts as a director for their own story, casting the others as actors. After all directors have presented one scene, the audience votes by applause to eliminate one story each round until a single \"Superscene\" remains.",
+      howToPlay:
+        "1. Three to five players participate. Each takes a turn as \"director\" of their own story.\n2. The director introduces the scene, asks the audience for guidelines, and may impose additional requirements (rhyme, genre, ABC-game, etc.).\n3. The other players perform the scene. The director ends it at a chosen moment.\n4. After all directors have presented, each briefly promotes their story to the audience.\n5. The audience votes by applause on each scene. The scene with the least applause is eliminated.\n6. The remaining directors receive additional audience guidelines for the next round. Play another round without the eliminated story.\n7. Repeat until one story remains — the \"Superscene\".",
+      variations: [],
+      tips: [
+        "Directors should only promote their own story — never comment on or disparage others.",
+        "End each scene with a cliff-hanger to make the audience curious and invested in seeing the sequel.",
+        "The goal is to arouse and maintain the audience's interest in the progress of the story across rounds.",
+        "Despite the competitive format, this is about creative cooperation — all players should give their best in every scene, regardless of whose story it is.",
+      ],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: german-content ──
+  {
+    id: "gefuehlspunkte",
+    category: "german-content",
+    input: {
+      name: "Gefühlspunkte",
+      languageCode: "de",
+      sourceName: "improwiki",
+      tags: ["Gefühlsspiele", "game"],
+      htmlContent: `
+<p>Es werden zwei gut sichtbare Punkte auf die Bühne geklebt. Jedem der beiden Punkte wird durch Publikumszuruf ein „Gefühl" zugeordnet (am besten gegensätzliche, z.B. Hass-Liebe, Eifersucht-Gleichgültigkeit, Trauer-Freude, ...).</p>
+<p>Nun gibt das Publikum noch einen Ort vor, an dem die zu improvisierende Szene entstehen soll. Die Spieler entwickeln nun eine zusammenhängende Geschichte, wobei sich die Charaktere frei auf der Bühne bewegen können, jedoch je nach Standort („Gefühlspunkt") ihre Figur unterschiedlich ausspielen, also in der entsprechenden Emotion einfärben. Die Emotion wird immer stärker, je näher die/der Spieler dem Gefühlspunkt kommt. Auf dem Gefühlspunkt gibt es dann den völligen Gefühlsausbruch!</p>
+<p>Etwas ähnlich ist das Spiel "Gefühlsquadrat".</p>
+<h3>Tipps und Hinweise</h3>
+<ul>
+<li>Wichtig ist es, nicht nur die Extreme auf den Gefühlspunkten zu spielen, sondern auch die Abstufungen der Gefühle zwischen diesen.</li>
+<li>Zusätzlich zum Ort kann man sich auch noch Gegenstände oder Raum- oder Ortsdetails geben lassen, die an dem betreffenden Gefühlspunkt vorhanden sind.</li>
+<li>Die (größeren) Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich erscheinen.</li>
+</ul>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Bei Gefühlspunkte werden zwei gut sichtbare Punkte auf die Bühne geklebt und jedem wird per Publikumszuruf ein gegensätzliches Gefühl zugeordnet (z.B. Hass und Liebe). Die Spieler improvisieren eine zusammenhängende Szene an einem vom Publikum vorgegebenen Ort, wobei sie ihre Figur je nach Nähe zu einem Gefühlspunkt in der entsprechenden Emotion einfärben — direkt auf dem Punkt erfolgt der völlige Gefühlsausbruch.",
+      howToPlay:
+        "1. Zwei gut sichtbare Punkte werden auf der Bühne markiert.\n2. Das Publikum ordnet jedem Punkt ein gegensätzliches Gefühl zu (z.B. Hass und Liebe, Eifersucht und Gleichgültigkeit).\n3. Das Publikum gibt einen Ort für die Szene vor.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je näher ein Spieler einem Gefühlspunkt kommt, desto stärker spielt er die entsprechende Emotion aus. Auf dem Punkt selbst erfolgt der völlige Gefühlsausbruch.",
+      variations: [],
+      tips: [
+        "Nicht nur die Extreme auf den Gefühlspunkten spielen, sondern auch die Abstufungen und Übergänge der Gefühle zwischen den Punkten.",
+        "Zusätzlich zum Ort kann das Publikum auch Gegenstände oder Raumdetails an den Gefühlspunkten vorgeben (z.B. ein Sessel am Hass-Punkt, ein Fernseher am Liebes-Punkt).",
+        "Größere Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich wirken.",
+      ],
+      referencedElements: ["Gefühlsquadrat"],
+    },
+  },
+
+  // ── Category: german-exercise ──
+  {
+    id: "distanz-schlaegerei",
+    category: "german-exercise",
+    input: {
+      name: "Distanz-Schlägerei",
+      languageCode: "de",
+      sourceName: "improwiki",
+      tags: ["Pantomime Übungen", "Aktion und Reaktion - Übungen", "exercise"],
+      htmlContent: `
+<p>Zwei Spieler stehen sich in angemessener Entfernung gegenüber. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer nutzt wechselnd Füße, Arme, Kopf, Schulter, um plötzlich und immer wieder den Verteidiger zu attackieren. Dies jedoch immer in sicherer Entfernung. Der Angegriffene reagiert spontan so, als wenn er wirklich getroffen worden wäre.</p>
+<p>Das Spiel kann entweder paarweise gespielt werden, oder die ganze Gruppe kämpft zugleich, "jeder gegen jeden".</p>
+<p>Die Übung ist zum Aufwärmen geeignet, gut zum Hemmungen- und Frust-Abbauen, und trainiert außerdem den Ausdruck.</p>
+<p>Siehe auch Zeitlupenschlägerei</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Distanz-Schlägerei ist eine pantomimische Aufwärmübung, bei der zwei Spieler in sicherer Entfernung einen Kampf simulieren. Der Angreifer attackiert mit wechselnden Körperteilen aus der Distanz, der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden. Die Übung kann paarweise oder in der ganzen Gruppe gespielt werden.",
+      howToPlay:
+        "1. Zwei Spieler stellen sich in angemessener Entfernung gegenüber auf.\n2. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer nutzt wechselnd Füße, Arme, Kopf und Schultern, um plötzlich und immer wieder zu attackieren — stets aus sicherer Entfernung.\n3. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden.\n4. Variante: Die ganze Gruppe kämpft gleichzeitig, \"jeder gegen jeden\".",
+      variations: [],
+      tips: [
+        "Die Übung eignet sich gut zum Aufwärmen, zum Hemmungen- und Frust-Abbauen und trainiert den körperlichen Ausdruck.",
+        "Trotz der Distanz muss der Verteidiger überzeugend und spontan auf jeden Angriff reagieren.",
+      ],
+      referencedElements: ["Zeitlupenschlägerei"],
+    },
+  },
+
+  // ── Category: learnimprov-structured ──
+  {
+    id: "harold-french",
+    category: "learnimprov-structured",
+    input: {
+      name: "Harold-French",
+      languageCode: "en",
+      sourceName: "learnimprov",
+      tags: ["Long Form"],
+      htmlContent: `
+<p>Synonyms: Herald, Sheila</p>
+<p>French Harold – A Harold that takes place in one environment.</p>
+<p>Introduction: We are about to perform a series of scenes loosely associated to one theme. May I get a general theme please.</p>
+<p>Description: The Harold is a series of scenes that are connected by a common general theme. The audience does not participate further with suggestions, and all 11 to 12 scenes are based on the chosen theme. The format was created by Del Close.</p>
+<p>The Most Common Format: 3 sets of 3 scenes. Any number of improvisers start riffing off the theme as a group (free associations, group song, etc.). 3 scenes follow, not related to each other but informed by the theme. Another handle is played. This cycle repeats 3 times for 9 open scenes total. By the last round, stories start to weave together.</p>
+<p>Scene Transitions: In a Harold, open scenes are not called by a booth — transitions are determined by offstage ensemble members (wipes). Types: clap, front wipe, tap out, ass wipe, technical, director cut.</p>
+<p>Variations: Monoscene – A Harold in one environment. Blind Harold – blindfolded in the dark. The Bat – unblindfolded Harold in the dark. Armando – scenes interceded by true story monologues. Sybil – performed by a single performer. The Narce – single performer Harold. Triple Play – 3 by 3 scenes with no interceding handles.</p>
+<p>Credits: Del Close</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Harold-French (also called Herald or Sheila) is a version of the Harold long-form improv format where all scenes take place in a single environment. The Harold itself is a classic structure of three sets of three scenes connected by a common theme, created by Del Close. Scene transitions are controlled by offstage ensemble members through various \"wipe\" techniques.",
+      howToPlay:
+        "1. Get a broad general theme from the audience (single word or phrase).\n2. The ensemble opens with a group riff on the theme — free associations, a group song, or similar.\n3. Play 3 open scenes informed by but not directly related to each other.\n4. Perform a predetermined group handle (another structured bit).\n5. Repeat this cycle 3 times total, for 9 open scenes. By the last round, stories should begin to weave together.\n6. Scene transitions are controlled by offstage members through wipes: clap, front wipe, tap out, lights dim, or coach call.",
+      variations: [
+        {
+          name: "Monoscene",
+          description: "A Harold that takes place in one environment.",
+        },
+        {
+          name: "Blind Harold",
+          description: "Participants are seated and blindfolded in the dark.",
+        },
+        {
+          name: "The Bat",
+          description: "Unblindfolded Harold performed in the dark.",
+        },
+        {
+          name: "Armando",
+          description: "Scenes are interceded by true story monologues from a designated monologist.",
+        },
+        {
+          name: "Triple Play",
+          description: "3 by 3 scenes with no interceding handles.",
+        },
+      ],
+      tips: [
+        "The theme should be as broad as possible. Nouns are discouraged. For example, \"toothbrush\" could be wrangled into the theme \"cleaning\".",
+        "A smart group will put their best storyteller as their balladeer, not the best singer.",
+      ],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: musical-form ──
+  {
+    id: "balladeer-doo-wop",
+    category: "musical-form",
+    input: {
+      name: "Balladeer-Doo Wop",
+      languageCode: "en",
+      sourceName: "learnimprov",
+      tags: ["Long Form"],
+      htmlContent: `
+<p>Synonyms: Minstrel, Musical MC, Doo Wop</p>
+<p>Introduction: The following improvisation will be longer than usual. It will be directed by a balladeer, yet remains entirely improvised.</p>
+<p>Description: The accompanist and the singer start off with a simple song that may introduce a character, a location, or foreshadow some event. The musical bits are meant to be short — thirty seconds to a minute. Simultaneously, players act on-stage silently while the balladeer sings, and start to vocalize as the ballad ends. The ballad is used to change scenes, rescue a struggling scene, or bring closure to a scene that has reached a conclusion. No blackouts — all changes are made by the balladeer. If the balladeer gets into trouble, the players need to step in with a scene. A smart group puts their best storyteller as balladeer, not the best singer.</p>
+<p>A new musical genre can be used for each new ballad: rap, rock, opera.</p>
+<p>Variations: Doo Wop — the balladeer is replaced by a group song in the style of Doo Wop. The group song could be any manner of group make-a-song (Hoe Down, March Song, Madrigal, Chant).</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Balladeer-Doo Wop (also known as Minstrel or Musical MC) is a long-form musical improv structure directed by a singing balladeer. The accompanist and singer introduce characters, locations, or events through short songs while actors perform silently on stage. The ballads control scene changes, rescues, and closures — there are no blackouts.",
+      howToPlay:
+        "1. An accompanist and singer (the balladeer) start with a short song (30–60 seconds) introducing a character, location, or foreshadowing an event.\n2. While the balladeer sings, players act on stage silently. When the ballad ends, they begin speaking.\n3. The balladeer uses subsequent ballads to change scenes, rescue struggling scenes, or bring scenes to a conclusion.\n4. No blackouts — all scene transitions are controlled by the balladeer.\n5. Each ballad can use a different musical genre: rap, rock, opera, etc.",
+      variations: [
+        {
+          name: "Doo Wop",
+          description: "The balladeer is replaced by a group song in the style of Doo Wop. The group song can be any form of group make-a-song — Hoe Down, March Song, Madrigal, or Chant.",
+        },
+      ],
+      tips: [
+        "Put your best storyteller as the balladeer, not necessarily the best singer.",
+        "If the balladeer gets into trouble, the players must step in with a scene to recover.",
+        "Musical bits should be short — thirty seconds to a minute is usually enough to pass on story information.",
+      ],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: handle-overlay ──
+  {
+    id: "translation-healthcare",
+    category: "handle-overlay",
+    input: {
+      name: "Translation-Healthcare",
+      languageCode: "en",
+      sourceName: "learnimprov",
+      tags: ["Handle"],
+      htmlContent: `
+<p>Introduction: In this scene there will be a translator facilitating a healthcare interaction. The patient speaks a non-existent gibberish language.</p>
+<p>Description: Healthcare translation is a handle overlaid on an open scene with a predetermined concept. Typically the patient speaks gibberish, though the healthcare worker could as well. This differs from typical translation scenes in that the translation is done for another performer while the audience observes.</p>
+<p>It is recommended that the host set up a non-existent language — robot, economist, whale, or toaster. Using gibberish for existing languages can lead to stereotyping for humour, which is punching down.</p>
+<p>The performers must create complete characters with movement and wants in addition to the gibberish, and maintain a narrative arc that explores the healthcare interaction.</p>
+<p>Gimmicks: Short translation for long gibberish (or vice versa), problems with idioms, differences in emotional content, dirty words.</p>
+<p>Variations: Translated Opera (singing gibberish), Translated Film (movie thematics), Bad Translator (real language translated by non-speaker), Mechanical Translator (using Google translate), Future In Laws (meet the parents/in-laws).</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "Translation-Healthcare is a handle overlaid on an open scene where a translator facilitates a healthcare interaction between a provider and a patient who speaks a made-up gibberish language. Unlike typical translation scenes, the translation is performed for another character on stage — not the audience — so the audience observes both sides. The format emphasizes character work, narrative arc, and avoiding cultural stereotypes.",
+      howToPlay:
+        "1. A host sets up a non-existent gibberish language (robot, economist, whale, toaster, etc.) and the healthcare scenario.\n2. One performer plays the patient speaking gibberish. Another plays the healthcare provider. A third translates between them.\n3. The patient communicates in gibberish with full physicality, emotion, and want; the translator interprets for the provider, and vice versa.\n4. Performers maintain a narrative arc exploring the healthcare interaction — not just the translation gimmick.",
+      variations: [
+        {
+          name: "Translated Opera",
+          description: "As described, with the gibberish sung.",
+        },
+        {
+          name: "Translated Film",
+          description: "As described, using movie thematics.",
+        },
+        {
+          name: "Bad Translator",
+          description: "Real language translated by a non-speaker of that language.",
+        },
+        {
+          name: "Mechanical Translator",
+          description: "Real language translated using Google Translate or similar.",
+        },
+        {
+          name: "Future In Laws",
+          description: "Meet the parents/in-laws through a translator.",
+        },
+      ],
+      tips: [
+        "Set up a non-existent language (robot, economist, whale) rather than using gibberish for real languages, which can lead to stereotyping.",
+        "Create complete characters with movement and wants — don't let the translation gimmick replace the narrative arc.",
+        "Short translation for long gibberish (or vice versa) is a classic comedy gimmick.",
+      ],
+      referencedElements: ["Gibberish"],
+    },
+  },
+
+  // ── Category: ask-for-edge ──
+  {
+    id: "what-did-you-want",
+    category: "ask-for-edge",
+    input: {
+      name: "What did you want to be when you grew up?",
+      languageCode: "en",
+      sourceName: "learnimprov",
+      tags: ["Ask For"],
+      htmlContent: "\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t",
+    },
+    expectedOutput: {
+      description:
+        "\"What did you want to be when you grew up?\" is an audience ask-for prompt from learnimprov.com. It is a question used to solicit suggestions from the audience to inspire an improv scene, not a game or exercise in itself.",
+      howToPlay: null,
+      variations: [],
+      tips: [],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: long-form-theory ──
+  {
+    id: "deconstruction",
+    category: "long-form-theory",
+    input: {
+      name: "Deconstruction",
+      languageCode: "en",
+      sourceName: "ircwiki",
+      tags: ["Improv Form", "Improv Forms"],
+      htmlContent: `
+<p>The Deconstruction is a long form structure developed by Del Close and The Family.</p>
+<h2>Structure</h2>
+<p>OPENING SCENE: A long (6-8min) two person scene that is all about providing information that will be used in the rest of the piece. This scene is all about relationship and exploring the problem that is presented (but not solved) in this opening scene.</p>
+<p>TWO (2) THEMATIC SCENES (2-3mins): Each THEMATIC SCENE is dedicated to exploring what the opening scene was ABOUT by taking what one of the Opening Scene's characters did and exploring their WANTS/FLAWS.</p>
+<p>RETURN TO THE OPENING SCENE (1 1/2-2mins): After seeing how others perceived the characters of the opening scene, the Opening Scene returns to clarify and solidify what the rest of the piece is ABOUT.</p>
+<p>FIVE (5) COMMENTARY SCENES (1 1/2-2mins long): These scenes comment on what was unusual or flawed about the characters in the Opening Scene. They are extremely game heavy and should focus on "bits" — straight man vs. absurd man.</p>
+<p>RETURN TO THE OPENING SCENE AGAIN (1 - 1 1/2 min): A quick return to the opening scene to heighten the stakes using ideas from the Commentary scenes. This is technically the first scene of "THE RUN".</p>
+<p>THE RUN: An intense series of ever-shorter scenes. Pace is as important, if not more important, than content. Anything goes. As long as you consistently pick up the pace until you reach a breakneck pace it will work.</p>
+<p>OPENING SCENE RETURNS/FINAL: The Opening Scene returns to wrap up the show for about 1 1/2 - 2mins. A classic technique is to go back in time — showing the characters before their conflict began, creating a poignant contrast.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "The Deconstruction is a long-form improv structure developed by Del Close and The Family. It starts with a long two-person opening scene that introduces characters and a central problem, then \"deconstructs\" that scene through thematic scenes, commentary scenes, and an accelerating run of ever-shorter callbacks, before returning to the opening scene for a final resolution.",
+      howToPlay:
+        "1. Opening Scene (6–8 min): A long two-person scene establishing relationship and a problem — present but not solve it.\n2. Two Thematic Scenes (2–3 min each): Scenes exploring what the opening scene was ABOUT, taking one character's wants/flaws into new contexts.\n3. Return to Opening Scene (1.5–2 min): Clarify and solidify the central theme.\n4. Five Commentary Scenes (1.5–2 min each): Game-heavy scenes that comment on what was unusual or flawed about the opening characters.\n5. Second Return to Opening (1–1.5 min): Heighten the stakes using ideas from the commentary scenes.\n6. The Run: An intense, accelerating series of ever-shorter scenes pulling tangents from earlier material at breakneck pace.\n7. Opening Scene Returns/Final (1.5–2 min): Wrap up the show, often by going back in time to before the conflict began.",
+      variations: [],
+      tips: [],
+      referencedElements: [],
+    },
+  },
+
+  // ── Category: concept-no-howtoplay ──
+  {
+    id: "game-concept",
+    category: "concept-no-howtoplay",
+    input: {
+      name: "Game",
+      languageCode: "en",
+      sourceName: "ircwiki",
+      tags: ["Concept", "Concepts"],
+      htmlContent: `
+<p>Game is an improvisational concept.</p>
+<h2>Game in longform and shortform improv</h2>
+<p>Longform and shortform improv use the word game to define substantial parts of their style.</p>
+<ul>
+<li>In shortform, game refers to a set of pre-determined rules that govern the general structure of any scene. There are many short form improv games.</li>
+<li>In longform, game is an improv concept used when describing what was interesting or funny about an improvisational scene.</li>
+</ul>
+<h2>Finding the Game</h2>
+<p>In order to find a game in a longform improv scene, you typically need to answer three questions:</p>
+<h3>What is the situation?</h3>
+<p>Who are the people in the scene, where are they and what are they doing? This can be established very quickly within a few lines.</p>
+<h3>What is the first unusual thing?</h3>
+<p>The first unusual thing is the first thing that a character does or says that sticks out like a sore thumb, something that feels out of place within the given situation.</p>
+<h3>If this is true, then what else is true?</h3>
+<p>Once we know what is out of the ordinary, we want to find variations that form a pattern of behavior, by asking "if this is true, what else is true". That way, we can explore and heighten that pattern to play the game.</p>
+      `.trim(),
+    },
+    expectedOutput: {
+      description:
+        "\"Game\" is a foundational improv concept with distinct meanings in shortform and longform. In shortform, a game is a set of pre-determined rules governing a scene's structure. In longform, the \"game of the scene\" is the interesting or funny pattern discovered during improvisation. Finding the game involves identifying the situation, spotting the first unusual thing, and asking \"if this is true, then what else is true?\" to heighten the pattern.",
+      howToPlay: null,
+      variations: [],
+      tips: [
+        "In shortform, a game is a set of pre-determined rules that govern the general structure of any scene.",
+        "In longform, find the game by answering three questions: What is the situation? What is the first unusual thing? If this is true, then what else is true?",
+        "The situation (who, where, what) can be established very quickly — within a few lines, or even through environment and object work before anyone speaks.",
+      ],
+      referencedElements: [],
+    },
+  },
+];

--- a/src/normalize/__testdata__/llm-client-parsing.test.ts
+++ b/src/normalize/__testdata__/llm-client-parsing.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+
+// Test the JSON extraction logic from llm-client.ts
+// (importing the internal function via a test helper)
+
+function extractJson(text: string): any {
+  // Replicate the extraction logic from llm-client.ts
+  const mdMatch = text.match(/```(?:json)?\s*\n?(\{[\s\S]*?\})\n?```/);
+  const jsonStr = mdMatch ? mdMatch[1].trim() : text.trim();
+  const objMatch = jsonStr.match(/\{[\s\S]*\}/);
+  const finalStr = objMatch ? objMatch[0] : jsonStr;
+  return JSON.parse(finalStr);
+}
+
+describe("llm-client JSON parsing", () => {
+  it("parses plain JSON", () => {
+    const result = extractJson('{"description":"test","howToPlay":"do this","variations":[],"tips":[],"referencedElements":[]}');
+    expect(result.description).toBe("test");
+    expect(result.howToPlay).toBe("do this");
+  });
+
+  it("parses JSON inside markdown code fence", () => {
+    const text = '```json\n{"description":"test","howToPlay":null,"variations":[],"tips":["tip 1"],"referencedElements":[]}\n```';
+    const result = extractJson(text);
+    expect(result.description).toBe("test");
+    expect(result.howToPlay).toBeNull();
+    expect(result.tips).toEqual(["tip 1"]);
+  });
+
+  it("parses JSON with leading text noise", () => {
+    const text = 'Here is the result:\n\n{"description":"test","howToPlay":"step 1\\nstep 2","variations":[{"name":"v1","description":"desc"}],"tips":[],"referencedElements":["Freeze Tag"]}\n\nHope this helps.';
+    const result = extractJson(text);
+    expect(result.description).toBe("test");
+    expect(result.howToPlay).toBe("step 1\nstep 2");
+    expect(result.variations[0].name).toBe("v1");
+    expect(result.referencedElements).toEqual(["Freeze Tag"]);
+  });
+
+  it("handles howToPlay as array", () => {
+    const text = '{"description":"test","howToPlay":["step 1","step 2","step 3"],"variations":[],"tips":[],"referencedElements":[]}';
+    const result = extractJson(text);
+    expect(Array.isArray(result.howToPlay)).toBe(true);
+    expect(result.howToPlay.length).toBe(3);
+  });
+
+  it("handles howToPlay as null for concepts", () => {
+    const text = '{"description":"a concept","howToPlay":null,"variations":[],"tips":["concepts are theoretical"],"referencedElements":[]}';
+    const result = extractJson(text);
+    expect(result.howToPlay).toBeNull();
+  });
+
+  it("handles empty fields", () => {
+    const text = '{"description":"","howToPlay":null,"variations":[],"tips":[],"referencedElements":[]}';
+    const result = extractJson(text);
+    expect(result.description).toBe("");
+    expect(result.variations).toEqual([]);
+    expect(result.tips).toEqual([]);
+  });
+
+  it("parses complex nested variations", () => {
+    const text = '{"description":"test","howToPlay":"step 1","variations":[{"name":"Blind Freeze","description":"Players face away"},{"name":"Elimination Freeze","description":"Competitive version"}],"tips":["tip 1","tip 2"],"referencedElements":["Gefühlsquadrat"]}';
+    const result = extractJson(text);
+    expect(result.variations.length).toBe(2);
+    expect(result.variations[0].name).toBe("Blind Freeze");
+    expect(result.variations[1].name).toBe("Elimination Freeze");
+    expect(result.referencedElements).toContain("Gefühlsquadrat");
+  });
+});

--- a/src/normalize/__testdata__/normalize-pipeline.test.ts
+++ b/src/normalize/__testdata__/normalize-pipeline.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import { createHash } from "crypto";
+import { buildRelatedIdentifiers } from "../cross-source-matching";
+import type { NormalizedElement } from "../normalized-schema";
+
+function hashContent(html: string): string {
+  return createHash("md5").update(html).digest("hex");
+}
+
+function makeElement(overrides: Partial<NormalizedElement> = {}): NormalizedElement {
+  return {
+    identifier: "test1234567890123456789012345678", // 32 chars
+    name: "Test Element",
+    url: "https://example.com/test",
+    sourceName: "improwiki",
+    languageCode: "en",
+    tags: ["game"],
+    htmlContent: "<p>Test content</p>",
+    normalized: {
+      description: "A test element.",
+      howToPlay: "1. Do this.\n2. Do that.",
+      variations: [],
+      tips: [],
+      referencedElements: [],
+      contentHash: hashContent("<p>Test content</p>"),
+      extractedAt: new Date().toISOString(),
+    },
+    derivedElements: [],
+    relatedIdentifiers: [],
+    ...overrides,
+  };
+}
+
+describe("normalize pipeline", () => {
+  it("content hash detects changes", () => {
+    const hash1 = hashContent("<p>Hello</p>");
+    const hash2 = hashContent("<p>Hello</p>");
+    const hash3 = hashContent("<p>Goodbye</p>");
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).not.toBe(hash3);
+  });
+
+  it("content hash is stable across invocations", () => {
+    const hash = hashContent("<p>Stable content</p>");
+    const hash2 = hashContent("<p>Stable content</p>");
+    expect(hash).toBe(hash2);
+    expect(hash).toHaveLength(32);
+  });
+
+  it("derived elements have parent back-reference", () => {
+    const el = makeElement({
+      derivedElements: [
+        {
+          name: "Blind Freeze",
+          description: "A variation where players face away.",
+          parentIdentifier: "test1234567890123456789012345678",
+        },
+      ],
+    });
+
+    expect(el.derivedElements.length).toBe(1);
+    expect(el.derivedElements[0].parentIdentifier).toBe(el.identifier);
+  });
+
+  it("derived elements are only created for substantial variations", () => {
+    // This is the threshold logic: variations with description > 40 chars
+    const short = "Short";
+    const long = "A".repeat(41);
+
+    expect(short.length > 40).toBe(false);
+    expect(long.length > 40).toBe(true);
+  });
+
+  it("relatedIdentifiers connects cross-source matches", () => {
+    const elements: NormalizedElement[] = [
+      makeElement({
+        identifier: "aaa111bbb222ccc333ddd444eee555f1",
+        name: "Freeze Tag",
+        sourceName: "improwiki",
+        relatedIdentifiers: ["bbb222ccc333ddd444eee555fff666g2"],
+      }),
+      makeElement({
+        identifier: "bbb222ccc333ddd444eee555fff666g2",
+        name: "Freeze Tag",
+        sourceName: "learnimprov",
+        relatedIdentifiers: ["aaa111bbb222ccc333ddd444eee555f1"],
+      }),
+    ];
+
+    expect(elements[0].relatedIdentifiers).toContain(elements[1].identifier);
+    expect(elements[1].relatedIdentifiers).toContain(elements[0].identifier);
+  });
+
+  it("cross-source matching finds exact name matches", () => {
+    const result = buildRelatedIdentifiers([
+      { identifier: "a1234567890123456789012345678a", name: "Freeze Tag", sourceName: "improwiki", languageCode: "en" },
+      { identifier: "b1234567890123456789012345678b", name: "Freeze Tag", sourceName: "learnimprov", languageCode: "en" },
+    ]);
+
+    expect(result.get("a1234567890123456789012345678a")).toContain("b1234567890123456789012345678b");
+    expect(result.get("b1234567890123456789012345678b")).toContain("a1234567890123456789012345678a");
+  });
+
+  it("normalized schema preserves all source metadata", () => {
+    const el = makeElement({
+      translationLinkEn: "https://example.com/en/test",
+      translationLinkDe: "https://example.com/de/test",
+      playerCountMin: 2,
+      playerCountMax: 8,
+      categories: ["warmup"],
+      postTags: ["circle"],
+    });
+
+    expect(el.translationLinkEn).toBeDefined();
+    expect(el.translationLinkDe).toBeDefined();
+    expect(el.playerCountMin).toBe(2);
+    expect(el.playerCountMax).toBe(8);
+    expect(el.categories).toContain("warmup");
+    expect(el.postTags).toContain("circle");
+  });
+
+  it("normalized element has all required fields", () => {
+    const el = makeElement();
+
+    expect(el.identifier).toHaveLength(32);
+    expect(el.name).toBeTruthy();
+    expect(el.url).toStartWith("https://");
+    expect(el.sourceName).toBeTruthy();
+    expect(el.normalized.description.length).toBeGreaterThan(0);
+    expect(Array.isArray(el.normalized.variations)).toBe(true);
+    expect(Array.isArray(el.normalized.tips)).toBe(true);
+    expect(Array.isArray(el.normalized.referencedElements)).toBe(true);
+    expect(el.normalized.contentHash).toHaveLength(32);
+    expect(el.normalized.extractedAt).toBeTruthy();
+  });
+});

--- a/src/normalize/__testdata__/results/comparison.json
+++ b/src/normalize/__testdata__/results/comparison.json
@@ -1,0 +1,1434 @@
+{
+  "meta": {
+    "opencodeVersion": "1.15.5",
+    "timestamp": "2026-06-03T16:52:27.640Z",
+    "runId": "2026-06-03T16-52-27-640Z",
+    "elementCount": 15
+  },
+  "models": [
+    {
+      "id": "pro",
+      "label": "deepseek-v4-pro",
+      "modelId": "opencode-go/deepseek-v4-pro",
+      "results": [
+        {
+          "elementId": "freeze-tag",
+          "name": "Freeze Tag",
+          "category": "well-structured-game",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Freeze Tag is a fast-paced improv game where two players start a scene, anyone calls \"Freeze!\" to lock them in position, and a new player taps in, assumes the frozen pose, and launches an entirely new, unrelated scene. It trains spontaneity, physicality, and the core improv principle of accepting what you are given and building on it. Also known as \"Freeze\", \"Zap\", \"Chain Impro\" or \"Tap Out\".",
+            "howToPlay": "1. Two players begin a scene with full physical commitment — moving, using the space, no \"talking heads\".\n2. Any waiting player shouts \"Freeze!\" or \"Stop!\" when the stage picture is strong or interesting.\n3. Both stage players freeze instantly in their exact poses — no drift, no relaxation.\n4. A waiting player steps forward, gently taps out one frozen player, and takes over that exact pose. The tapped-out player leaves the stage.\n5. The new player immediately begins a completely new scene, justifying the pose with fresh characters, setting, and story — totally unrelated to the previous scene.\n6. Repeat until the group decides to end.",
+            "variations": [
+              {
+                "name": "Blind Freeze",
+                "description": "Waiting players stand with their backs to the stage. They call \"stop\", turn around, and must work with whatever picture they find. Prevents pre-planning and pushes pure spontaneity."
+              },
+              {
+                "name": "Elimination Freeze",
+                "description": "Competitive version. Players who hesitate, lack ideas, or stall in justification are eliminated. The last remaining player is the \"freeze king\". Works especially well in shows."
+              },
+              {
+                "name": "Object Freeze",
+                "description": "Poses must involve interaction with an invisible object. Every new scene defines what object is being held or manipulated by the body posture."
+              }
+            ],
+            "tips": [
+              "Avoid the obvious continuation — a raised arm doesn't always have to be a traffic cop. Take the idea one step further.",
+              "Give extreme and dynamic poses as gifts when you are on stage. Static standing offers no inspiration to the next player.",
+              "Time the freeze when the stage picture is especially strong or a conflict has just peaked — not too early, not too late.",
+              "Watch colleagues' poses carefully from the sideline. Inaccurate pose reproduction leads to a wooden new scene start."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Freeze Tag is a fast-paced improv game where players steal a frozen body posture and breathe new life into it in a completely different scene. It's a classic warm-up and performance game that trains spontaneity and the 'yes, and' principle.",
+            "howToPlay": "1. All players form a loose half-circle at the edge of the stage. Two players step out and begin a scene with full physical commitment.\n2. The two players move, use the space and react to each other. No 'talking heads'.\n3. Any waiting player can shout 'Freeze!' or 'Stop!' when the picture on stage is strong or interesting.\n4. Both stage players freeze instantly in their exact poses. No drift, no relaxation.\n5. A waiting player walks on, gently taps out one of the frozen players and takes over that exact pose.\n6. The new player justifies the pose with a completely fresh scene. Story, setting and characters have nothing to do with what came before.",
+            "variations": [
+              {
+                "name": "Blind Freeze",
+                "description": "Waiting players stand with their back to the stage. Whoever feels the time is right calls 'stop', turns around and has to work with whatever picture they find, pushing pure spontaneity."
+              },
+              {
+                "name": "Elimination Freeze",
+                "description": "Competitive version where anyone who lacks a quick idea, hesitates too long or stalls is out. At the end one 'freeze king' remains."
+              },
+              {
+                "name": "Object Freeze",
+                "description": "Focus is on poses involving interaction with an invisible object. Every new scene must define an object held or moved by the body posture."
+              }
+            ],
+            "tips": [
+              "Avoid the obvious continuation. If someone is frozen with a raised arm, the policeman directing traffic is the first idea everyone has. Try to take a step further.",
+              "Give extreme poses as gifts. Putting yourself in uncomfortable or dynamic positions is a wonderful gift to your colleagues.",
+              "A good freeze hits when the picture is especially strong or when a conflict has just reached its peak.",
+              "Watch carefully. Whoever stands at the side of the stage shouldn't only be thinking about their own next idea."
+            ],
+            "referencedElements": [
+              "Zap",
+              "Chain Impro",
+              "Tap Out",
+              "Blind Freeze",
+              "Elimination Freeze",
+              "Object Freeze"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.75,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "half-life",
+          "name": "Half-Life",
+          "category": "inline-variant",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Half-Life (also known as Fast Forward) is an improv game where a scene is first played in one minute, then repeated in ever-shorter time frames — 30, 15, 7, 3, and finally 1 second. The rapid compression forces players to strip each repetition down to the essential beats, and the resulting slapstick effect reliably generates laughs even from weak starting material.",
+            "howToPlay": "1. Ask the audience for a dramatic situation to start the scene.\n2. Play a scene with as much action as possible — location changes, dialogue, drama.\n3. After one minute, repeat the same scene in 30 seconds, hitting all the key anchor points.\n4. Repeat again in 15 seconds, then 7, then 3, then 1 second, each time compressing to the essentials.",
+            "variations": [
+              {
+                "name": "Variable Start Length",
+                "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+              }
+            ],
+            "tips": [
+              "Ask the audience for a suggestion based on a dramatic situation — it gives the scene stakes from the start.",
+              "The starting scene should contain as much action as possible: changes of location, dialogue, drama — the more material, the funnier the compressions.",
+              "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Half-Life (also known as Fast Forward) is an improv game where a scene is played within one minute and then repeated in progressively shorter time frames of 30, 15, 7, 3, and finally 1 second. The shortening forces players to reduce the scene to its essentials, creating a guaranteed laugh through slapstick compression.",
+            "howToPlay": "1. Ask the audience for a suggestion based on a dramatic situation.\n2. Play a starting scene within one minute, filled with as much action as possible: changes of location, dialogue, and drama.\n3. Repeat the scene in 30 seconds, keeping the key anchor points of the original scene.\n4. Repeat the scene in 15 seconds, further compressing to essentials.\n5. Repeat the scene in 7 seconds.\n6. Repeat the scene in 3 seconds.\n7. Repeat the scene in 1 second.",
+            "variations": [
+              {
+                "name": "Flexible Start",
+                "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+              }
+            ],
+            "tips": [
+              "It helps to ask the audience for a suggestion based on a dramatic situation.",
+              "The starting scene should contain as much action as possible: changes of location, dialogue, drama and so on.",
+              "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats.",
+              "The audience enjoys watching the players struggle, race against the clock and end up completely out of breath."
+            ],
+            "referencedElements": [
+              "Fast Forward"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 0,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "yes-no",
+          "name": "Yes - No",
+          "category": "minimal-content",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Yes - No is a simple paired improv exercise where one player can only say \"Yes\" and the other only \"No\". Despite having just one word each, they carry out a full conversation using tone, volume, rhythm, pauses, and body language. Roles are swapped partway through.",
+            "howToPlay": "1. Form pairs. One player may only say \"Yes\", the other only \"No\".\n2. Have a full conversation despite the limitation, using tone, volume, rhythm, pauses, and body language to convey meaning.\n3. After a while, switch roles so each player experiences both constraints.",
+            "variations": [],
+            "tips": [
+              "Communication is mostly non-verbal — this exercise makes that vivid by restricting vocabulary to a single word each.",
+              "Use tone, volume, rhythm, and pauses to differentiate between question, statement, anger, excitement, and other meanings."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "An improv exercise where players form pairs. One can only say 'Yes', the other only 'No'. Despite this verbal limitation, they have a full conversation using tone, volume, rhythm, pauses, and body language. After a while, roles switch.",
+            "howToPlay": "1. Form pairs.\n2. One player can only say 'Yes', the other only 'No'.\n3. Have a full conversation using only these words, relying on tone, volume, rhythm, pauses, and body language to communicate meaning.\n4. After a while, switch roles so the 'Yes' player becomes 'No' and vice versa.",
+            "variations": [],
+            "tips": [
+              "Use tone, volume, rhythm, pauses, and body language to convey meaning beyond the single word.",
+              "This exercise trains vocal expression and status play.",
+              "Communication is mostly non-verbal — embrace that realization."
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.5,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "mirror-exercises",
+          "name": "Mirror Exercises",
+          "category": "short-exercise",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Mirror Exercises is a classic paired improv warm-up where two players face each other and one mirrors the other's slow movements exactly. The goal is for an outside observer to be unable to tell who is leading and who is following. It trains observation, patience, and physical synchronization.",
+            "howToPlay": "1. Two players face each other. One leads with slow, deliberate movements while the other mirrors exactly.\n2. The goal is for an observer to not be able to tell who leads.\n3. Switch roles after a while.\n4. Eventually, try leading and following simultaneously with no designated leader.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "A classic improv exercise where two players face each other. One leads with slow movements while the other mirrors exactly, with the goal that an observer cannot tell who is leading. Over time, players switch roles and eventually try leading and following simultaneously with no designated leader.",
+            "howToPlay": "1. Two players face each other.\n2. One player leads with slow, deliberate movements while the other mirrors exactly, as if looking in a mirror.\n3. The goal is for an observer to not be able to tell who is leading.\n4. After a while, switch roles so the other player leads.\n5. Eventually, try leading and following simultaneously with no designated leader.",
+            "variations": [],
+            "tips": [
+              "Move slowly and deliberately so the partner can follow precisely.",
+              "The goal is for an observer to not be able to tell who is leading.",
+              "This exercise trains observation, patience, and physical synchronization."
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "talk-at-touch",
+          "name": "Talk at touch",
+          "category": "medium-game",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Talk at touch is a two-player improv game where speaking is only allowed while one player is physically touching the other, and only the player who initiated the touch may talk. Permanent contact like holding hands is prohibited. The constant alternation between mute physical play and spoken sections creates comedy from the necessity to touch in order to communicate.",
+            "howToPlay": "1. Two players perform a scene, optionally with an audience suggestion.\n2. A player may only speak while touching the other player, and only the touching player may talk.\n3. Permanent contact such as holding hands is prohibited — touch must be initiated anew each time.\n4. This produces a rhythm of mute physical sections alternating with spoken dialogue.",
+            "variations": [
+              {
+                "name": "Bidirectional Touch",
+                "description": "A touch is valid in both directions: as soon as contact exists, both players may speak regardless of who initiated it. When contact breaks, both must be silent and can only play pantomime."
+              }
+            ],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "An improv game where two players perform a scene but are only allowed to speak while physically touching each other. Only the person who initiates the touch may speak. Permanent contact such as holding hands is prohibited. This creates a rhythm alternating between mute pantomime and spoken sections.",
+            "howToPlay": "1. Two players perform a scene, optionally with input from the audience.\n2. Players may only speak while one player is touching the other.\n3. Only the person who initiates the touch is allowed to speak.\n4. Permanent contact such as holding hands is prohibited.\n5. Players alternate between mute pantomime sections and spoken sections, creating comedy from the necessity to touch in order to communicate.",
+            "variations": [
+              {
+                "name": "Bidirectional Touch",
+                "description": "A touch is valid in both directions — as soon as contact is made, both may speak regardless of who initiated the touch. As soon as contact breaks, both must be silent and can only play pantomime."
+              }
+            ],
+            "tips": [
+              "The comedy arises from the necessity of players to touch each other in order to communicate.",
+              "Use the mute sections for physical storytelling and pantomime.",
+              "Avoid permanent contact like holding hands — the alternating rhythm of touch and release is key."
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "swinging-pendulum",
+          "name": "Swinging Pendulum of Death",
+          "category": "external-refs",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Swinging Pendulum of Death is a complex three-player improv game with strong narrative structure. Each player is given a distinct character, location, and conflict. The game cycles through three locations, with one character dying at each, then repeatedly revisits locations at random — requiring the actor who died there to drop dead instantly while the others deal with the aftermath.",
+            "howToPlay": "1. Assign each of three actors a location, a conflict, and a character.\n2. Start at the first actor's location. The other two adapt to fit that scenario. Play the scene until that actor's character dies.\n3. The judge calls a new location. The actor who just died returns as a new character. Play the scene until the second actor's character dies.\n4. Repeat for the third location until the third character dies.\n5. Once all three deaths are established, the judge calls locations at random. The actor who died in that location immediately drops dead, and the others continue the aftermath. Repeat until the game ends.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "The Swinging Pendulum of Death is a complex and entertaining improv game for 3 actors. Each actor is given a location, conflict, and character. Scenes are played at each location where one character dies, then the game cycles through locations at random as the dead character immediately drops dead and the others deal with the aftermath.",
+            "howToPlay": "1. Each of the 3 actors is given a location, a conflict, and a character, based on audience suggestions.\n2. The game starts at the first location. The actor whose character belongs to that location is established, and the other two actors play supporting characters. The scene must be built up to the point that the main character dies.\n3. A judge calls out one of the other two locations. The dead actor 'comes back to life' as a new character within the new location, and the scene is advanced until another character dies.\n4. Repeat for the third location, where the previously dead character comes to life again and the scene is played until the third character dies.\n5. After all three deaths are established, the judge calls any location at random. The actor who died in that location must immediately drop dead, and the others pick up where the scene left off, dealing with the aftermath of the death.\n6. Continue calling locations at random until the end of the game.",
+            "variations": [],
+            "tips": [
+              "This game is complicated but can be extremely entertaining if done well.",
+              "Each scene must be advanced to the point that the designated character dies.",
+              "When a location is called after all deaths, the actor who died there must drop dead immediately and the others must react to the aftermath."
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "superscene",
+          "name": "Superscene",
+          "category": "long-form-show",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Superscene is a long-form improv show format for three to five players, structured as a competitive storytelling tournament. Each player acts as a director for their own story, casting the others as actors. After all directors have presented one scene, the audience votes by applause to eliminate one story each round until a single \"Superscene\" remains.",
+            "howToPlay": "1. Three to five players participate. Each takes a turn as \"director\" of their own story.\n2. The director introduces the scene, asks the audience for guidelines, and may impose additional requirements (rhyme, genre, ABC-game, etc.).\n3. The other players perform the scene. The director ends it at a chosen moment.\n4. After all directors have presented, each briefly promotes their story to the audience.\n5. The audience votes by applause on each scene. The scene with the least applause is eliminated.\n6. The remaining directors receive additional audience guidelines for the next round. Play another round without the eliminated story.\n7. Repeat until one story remains — the \"Superscene\".",
+            "variations": [],
+            "tips": [
+              "Directors should only promote their own story — never comment on or disparage others.",
+              "End each scene with a cliff-hanger to make the audience curious and invested in seeing the sequel.",
+              "The goal is to arouse and maintain the audience's interest in the progress of the story across rounds.",
+              "Despite the competitive format, this is about creative cooperation — all players should give their best in every scene, regardless of whose story it is."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Superscene is an improv game for three to five players where each takes a turn as director of their own story scene. After all scenes are performed, the audience votes by applause, eliminating one story each round until a single 'Superscene' remains as the audience's favorite.",
+            "howToPlay": "1. Three to five players participate. Each is responsible for one story as its director.\n2. The first director introduces their scene and asks the audience for guidelines (e.g., location, genre, or other constraints).\n3. The other players perform the scene. At a given time, the director ends the scene.\n4. The next player becomes director, introduces their scene with new guidelines, and it is performed. This continues until all players have directed once.\n5. All directors briefly promote their story and explain why the audience should see its sequel.\n6. The audience votes by applause on each scene. The scene with the least applause is eliminated.\n7. For the second round, each remaining director receives additional guidelines from the audience and optional suggestions from other players. Scenes are performed and voted on again, with one eliminated.\n8. Repeat until one story remains — the 'Superscene'.",
+            "variations": [],
+            "tips": [
+              "Directors only promote their own story — they should not comment on or disparage others.",
+              "It is sensible to end each scene with a cliff-hanger.",
+              "The director does not cut off the continuing scene by the rules any more.",
+              "Even though directors are supposedly competitors, all should still try to give their best in every scene."
+            ],
+            "referencedElements": [
+              "ABC-game"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.25,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "gefuehlspunkte",
+          "name": "Gefühlspunkte",
+          "category": "german-content",
+          "source": "improwiki",
+          "lang": "de",
+          "expected": {
+            "description": "Bei Gefühlspunkte werden zwei gut sichtbare Punkte auf die Bühne geklebt und jedem wird per Publikumszuruf ein gegensätzliches Gefühl zugeordnet (z.B. Hass und Liebe). Die Spieler improvisieren eine zusammenhängende Szene an einem vom Publikum vorgegebenen Ort, wobei sie ihre Figur je nach Nähe zu einem Gefühlspunkt in der entsprechenden Emotion einfärben — direkt auf dem Punkt erfolgt der völlige Gefühlsausbruch.",
+            "howToPlay": "1. Zwei gut sichtbare Punkte werden auf der Bühne markiert.\n2. Das Publikum ordnet jedem Punkt ein gegensätzliches Gefühl zu (z.B. Hass und Liebe, Eifersucht und Gleichgültigkeit).\n3. Das Publikum gibt einen Ort für die Szene vor.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je näher ein Spieler einem Gefühlspunkt kommt, desto stärker spielt er die entsprechende Emotion aus. Auf dem Punkt selbst erfolgt der völlige Gefühlsausbruch.",
+            "variations": [],
+            "tips": [
+              "Nicht nur die Extreme auf den Gefühlspunkten spielen, sondern auch die Abstufungen und Übergänge der Gefühle zwischen den Punkten.",
+              "Zusätzlich zum Ort kann das Publikum auch Gegenstände oder Raumdetails an den Gefühlspunkten vorgeben (z.B. ein Sessel am Hass-Punkt, ein Fernseher am Liebes-Punkt).",
+              "Größere Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich wirken."
+            ],
+            "referencedElements": [
+              "Gefühlsquadrat"
+            ]
+          },
+          "actual": {
+            "description": "Zwei gut sichtbare Punkte werden auf die Bühne geklebt. Jedem Punkt wird durch Publikumszuruf ein Gefühl zugeordnet. Die Spieler entwickeln eine zusammenhängende Geschichte, wobei sich die Charaktere frei auf der Bühne bewegen können und je nach Standort zum Gefühlspunkt ihre Figur in der entsprechenden Emotion einfärben. Die Emotion wird stärker, je näher der Spieler dem Punkt kommt.",
+            "howToPlay": "1. Zwei gut sichtbare Punkte auf die Bühne kleben.\n2. Jedem Punkt wird durch Publikumszuruf ein Gefühl zugeordnet, am besten gegensätzliche (z.B. Hass–Liebe, Eifersucht–Gleichgültigkeit, Trauer–Freude).\n3. Das Publikum gibt einen Ort vor, an dem die Szene entstehen soll.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je nach Standort des Spielers (Nähe zu einem Gefühlspunkt) wird die Figur unterschiedlich in der entsprechenden Emotion gespielt.\n6. Die Emotion wird immer stärker, je näher der Spieler dem Gefühlspunkt kommt. Auf dem Gefühlspunkt gibt es den völligen Gefühlsausbruch.",
+            "variations": [],
+            "tips": [
+              "Es ist wichtig, nicht nur die Extreme auf den Gefühlspunkten zu spielen, sondern auch die Abstufungen der Gefühle zwischen diesen.",
+              "Zusätzlich zum Ort kann man sich auch noch Gegenstände oder Raum- oder Ortsdetails geben lassen, die an dem betreffenden Gefühlspunkt vorhanden sind.",
+              "Die größeren Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich erscheinen."
+            ],
+            "referencedElements": [
+              "Gefühlsquadrat"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.6666666666666666,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "distanz-schlaegerei",
+          "name": "Distanz-Schlägerei",
+          "category": "german-exercise",
+          "source": "improwiki",
+          "lang": "de",
+          "expected": {
+            "description": "Distanz-Schlägerei ist eine pantomimische Aufwärmübung, bei der zwei Spieler in sicherer Entfernung einen Kampf simulieren. Der Angreifer attackiert mit wechselnden Körperteilen aus der Distanz, der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden. Die Übung kann paarweise oder in der ganzen Gruppe gespielt werden.",
+            "howToPlay": "1. Zwei Spieler stellen sich in angemessener Entfernung gegenüber auf.\n2. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer nutzt wechselnd Füße, Arme, Kopf und Schultern, um plötzlich und immer wieder zu attackieren — stets aus sicherer Entfernung.\n3. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden.\n4. Variante: Die ganze Gruppe kämpft gleichzeitig, \"jeder gegen jeden\".",
+            "variations": [],
+            "tips": [
+              "Die Übung eignet sich gut zum Aufwärmen, zum Hemmungen- und Frust-Abbauen und trainiert den körperlichen Ausdruck.",
+              "Trotz der Distanz muss der Verteidiger überzeugend und spontan auf jeden Angriff reagieren."
+            ],
+            "referencedElements": [
+              "Zeitlupenschlägerei"
+            ]
+          },
+          "actual": {
+            "description": "Zwei Spieler stehen sich in angemessener Entfernung gegenüber. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer attackiert plötzlich mit Füßen, Armen, Kopf oder Schulter, jedoch immer in sicherer Entfernung. Der Angegriffene reagiert spontan, als ob er wirklich getroffen worden wäre. Die Übung dient zum Aufwärmen, Hemmungen- und Frust-Abbauen und trainiert den Ausdruck.",
+            "howToPlay": "1. Zwei Spieler stellen sich in angemessener Entfernung gegenüber.\n2. Einer ist der Angreifer, der andere der Verteidiger.\n3. Der Angreifer nutzt wechselnd Füße, Arme, Kopf, Schulter, um plötzlich und immer wieder den Verteidiger zu attackieren — jedoch immer in sicherer Entfernung.\n4. Der Angegriffene reagiert spontan so, als wenn er wirklich getroffen worden wäre.\n5. Optional kann das Spiel paarweise oder mit der ganzen Gruppe 'jeder gegen jeden' gespielt werden.",
+            "variations": [],
+            "tips": [
+              "Die Übung ist zum Aufwärmen geeignet und gut zum Hemmungen- und Frust-Abbauen.",
+              "Die Distanz muss immer sicher bleiben — kein tatsächlicher Körperkontakt.",
+              "Die Reaktionen des Verteidigers sollten spontan und realistisch wirken."
+            ],
+            "referencedElements": [
+              "Zeitlupenschlägerei"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.5,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "harold-french",
+          "name": "Harold-French",
+          "category": "learnimprov-structured",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "Harold-French (also called Herald or Sheila) is a version of the Harold long-form improv format where all scenes take place in a single environment. The Harold itself is a classic structure of three sets of three scenes connected by a common theme, created by Del Close. Scene transitions are controlled by offstage ensemble members through various \"wipe\" techniques.",
+            "howToPlay": "1. Get a broad general theme from the audience (single word or phrase).\n2. The ensemble opens with a group riff on the theme — free associations, a group song, or similar.\n3. Play 3 open scenes informed by but not directly related to each other.\n4. Perform a predetermined group handle (another structured bit).\n5. Repeat this cycle 3 times total, for 9 open scenes. By the last round, stories should begin to weave together.\n6. Scene transitions are controlled by offstage members through wipes: clap, front wipe, tap out, lights dim, or coach call.",
+            "variations": [
+              {
+                "name": "Monoscene",
+                "description": "A Harold that takes place in one environment."
+              },
+              {
+                "name": "Blind Harold",
+                "description": "Participants are seated and blindfolded in the dark."
+              },
+              {
+                "name": "The Bat",
+                "description": "Unblindfolded Harold performed in the dark."
+              },
+              {
+                "name": "Armando",
+                "description": "Scenes are interceded by true story monologues from a designated monologist."
+              },
+              {
+                "name": "Triple Play",
+                "description": "3 by 3 scenes with no interceding handles."
+              }
+            ],
+            "tips": [
+              "The theme should be as broad as possible. Nouns are discouraged. For example, \"toothbrush\" could be wrangled into the theme \"cleaning\".",
+              "A smart group will put their best storyteller as their balladeer, not the best singer."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "French Harold (also called Herald or Sheila) is a long-form improv structure that takes place in one environment. It consists of a series of scenes loosely associated to one common theme, typically following a format of 3 sets of 3 scenes interceded by group handles. The format was created by Del Close.",
+            "howToPlay": "1. Ask the audience for a general theme.\n2. Any number of improvisers riff off the theme as a group (free associations, group song, etc.) as an opening handle.\n3. Perform 3 open scenes, not related to each other but informed by the theme.\n4. Play another group handle.\n5. Repeat the cycle of 3 scenes followed by a handle two more times, for a total of 9 open scenes.\n6. By the last round, stories should start to weave together.\n7. Scene transitions are determined by offstage ensemble members using wipes (clap, front wipe, tap out, ass wipe, technical, director cut).",
+            "variations": [
+              {
+                "name": "Monoscene",
+                "description": "A Harold that takes place in one environment."
+              },
+              {
+                "name": "Blind Harold",
+                "description": "A Harold performed blindfolded in the dark."
+              },
+              {
+                "name": "The Bat",
+                "description": "An unblindfolded Harold performed in the dark."
+              },
+              {
+                "name": "Armando",
+                "description": "A Harold where scenes are interceded by true story monologues."
+              },
+              {
+                "name": "Sybil",
+                "description": "A Harold performed by a single performer."
+              },
+              {
+                "name": "The Narce",
+                "description": "A single performer Harold."
+              },
+              {
+                "name": "Triple Play",
+                "description": "3 by 3 scenes with no interceding handles."
+              }
+            ],
+            "tips": [
+              "The audience does not participate further with suggestions after the initial theme.",
+              "All 11 to 12 scenes should be based on the chosen theme.",
+              "Transitions are determined by offstage ensemble members, not called from a booth.",
+              "By the last round of scenes, stories should start to weave together."
+            ],
+            "referencedElements": [
+              "Monoscene",
+              "Blind Harold",
+              "The Bat",
+              "Armando",
+              "Sybil",
+              "The Narce",
+              "Triple Play",
+              "Del Close",
+              "Herald",
+              "Sheila"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "balladeer-doo-wop",
+          "name": "Balladeer-Doo Wop",
+          "category": "musical-form",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "Balladeer-Doo Wop (also known as Minstrel or Musical MC) is a long-form musical improv structure directed by a singing balladeer. The accompanist and singer introduce characters, locations, or events through short songs while actors perform silently on stage. The ballads control scene changes, rescues, and closures — there are no blackouts.",
+            "howToPlay": "1. An accompanist and singer (the balladeer) start with a short song (30–60 seconds) introducing a character, location, or foreshadowing an event.\n2. While the balladeer sings, players act on stage silently. When the ballad ends, they begin speaking.\n3. The balladeer uses subsequent ballads to change scenes, rescue struggling scenes, or bring scenes to a conclusion.\n4. No blackouts — all scene transitions are controlled by the balladeer.\n5. Each ballad can use a different musical genre: rap, rock, opera, etc.",
+            "variations": [
+              {
+                "name": "Doo Wop",
+                "description": "The balladeer is replaced by a group song in the style of Doo Wop. The group song can be any form of group make-a-song — Hoe Down, March Song, Madrigal, or Chant."
+              }
+            ],
+            "tips": [
+              "Put your best storyteller as the balladeer, not necessarily the best singer.",
+              "If the balladeer gets into trouble, the players must step in with a scene to recover.",
+              "Musical bits should be short — thirty seconds to a minute is usually enough to pass on story information."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Balladeer (also known as Minstrel, Musical MC, or Doo Wop) is an improv format where a singer and accompanist direct scenes through short improvised songs. The balladeer introduces characters, locations, or events through song while actors perform silently on stage, then begin vocalizing as the ballad ends. The ballad is used to change scenes, rescue struggling scenes, or bring closure.",
+            "howToPlay": "1. The accompanist and the singer start with a short song (30 seconds to 1 minute) that may introduce a character, location, or foreshadow an event.\n2. Simultaneously, players act on-stage silently while the balladeer sings.\n3. As the ballad ends, the on-stage players start to vocalize and perform the scene.\n4. The balladeer uses subsequent ballads to change scenes, rescue a struggling scene, or bring closure to a scene that has reached a conclusion.\n5. No blackouts are used — all changes are made by the balladeer.\n6. If the balladeer gets into trouble, the players need to step in with a scene.",
+            "variations": [
+              {
+                "name": "Doo Wop",
+                "description": "The balladeer is replaced by a group song in the style of Doo Wop. The group song could be any manner of group make-a-song such as Hoe Down, March Song, Madrigal, or Chant."
+              }
+            ],
+            "tips": [
+              "A new musical genre can be used for each new ballad: rap, rock, opera.",
+              "The musical bits are meant to be short — thirty seconds to a minute.",
+              "A smart group puts their best storyteller as balladeer, not the best singer.",
+              "If the balladeer gets into trouble, the players need to step in with a scene."
+            ],
+            "referencedElements": [
+              "Minstrel",
+              "Musical MC",
+              "Doo Wop",
+              "Hoe Down",
+              "March Song",
+              "Madrigal",
+              "Chant"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "translation-healthcare",
+          "name": "Translation-Healthcare",
+          "category": "handle-overlay",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "Translation-Healthcare is a handle overlaid on an open scene where a translator facilitates a healthcare interaction between a provider and a patient who speaks a made-up gibberish language. Unlike typical translation scenes, the translation is performed for another character on stage — not the audience — so the audience observes both sides. The format emphasizes character work, narrative arc, and avoiding cultural stereotypes.",
+            "howToPlay": "1. A host sets up a non-existent gibberish language (robot, economist, whale, toaster, etc.) and the healthcare scenario.\n2. One performer plays the patient speaking gibberish. Another plays the healthcare provider. A third translates between them.\n3. The patient communicates in gibberish with full physicality, emotion, and want; the translator interprets for the provider, and vice versa.\n4. Performers maintain a narrative arc exploring the healthcare interaction — not just the translation gimmick.",
+            "variations": [
+              {
+                "name": "Translated Opera",
+                "description": "As described, with the gibberish sung."
+              },
+              {
+                "name": "Translated Film",
+                "description": "As described, using movie thematics."
+              },
+              {
+                "name": "Bad Translator",
+                "description": "Real language translated by a non-speaker of that language."
+              },
+              {
+                "name": "Mechanical Translator",
+                "description": "Real language translated using Google Translate or similar."
+              },
+              {
+                "name": "Future In Laws",
+                "description": "Meet the parents/in-laws through a translator."
+              }
+            ],
+            "tips": [
+              "Set up a non-existent language (robot, economist, whale) rather than using gibberish for real languages, which can lead to stereotyping.",
+              "Create complete characters with movement and wants — don't let the translation gimmick replace the narrative arc.",
+              "Short translation for long gibberish (or vice versa) is a classic comedy gimmick."
+            ],
+            "referencedElements": [
+              "Gibberish"
+            ]
+          },
+          "actual": {
+            "description": "Translation-Healthcare is an improv handle overlaid on an open scene where a translator facilitates a healthcare interaction. The patient (or healthcare worker) speaks a non-existent gibberish language while the translator interprets. Performers must create complete characters with movement and wants in addition to the gibberish, maintaining a narrative arc around the healthcare interaction.",
+            "howToPlay": "1. The host sets up a non-existent language for the patient or healthcare worker (e.g., robot, economist, whale, toaster) — avoid using gibberish for existing languages to prevent stereotyping.\n2. The translator facilitates communication between the healthcare worker and the patient, translating the gibberish for the other performer while the audience observes.\n3. The performers create complete characters with movement and wants in addition to the gibberish.\n4. Maintain a narrative arc that explores the healthcare interaction throughout the scene.",
+            "variations": [
+              {
+                "name": "Translated Opera",
+                "description": "Singing gibberish in an operatic style."
+              },
+              {
+                "name": "Translated Film",
+                "description": "Using movie thematics with the translation format."
+              },
+              {
+                "name": "Bad Translator",
+                "description": "A real language is translated by a non-speaker."
+              },
+              {
+                "name": "Mechanical Translator",
+                "description": "Using a Google Translate style mechanical translation."
+              },
+              {
+                "name": "Future In Laws",
+                "description": "Meet the parents or in-laws scenario with translation."
+              }
+            ],
+            "tips": [
+              "It is recommended to set up a non-existent language — using gibberish for existing languages can lead to stereotyping.",
+              "The performers must create complete characters with movement and wants in addition to the gibberish.",
+              "Gimmicks that work well: short translation for long gibberish (or vice versa), problems with idioms, differences in emotional content, dirty words."
+            ],
+            "referencedElements": [
+              "Translated Opera",
+              "Translated Film",
+              "Bad Translator",
+              "Mechanical Translator",
+              "Future In Laws"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.6666666666666666,
+            "refRecall": 0
+          }
+        },
+        {
+          "elementId": "what-did-you-want",
+          "name": "What did you want to be when you grew up?",
+          "category": "ask-for-edge",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "\"What did you want to be when you grew up?\" is an audience ask-for prompt from learnimprov.com. It is a question used to solicit suggestions from the audience to inspire an improv scene, not a game or exercise in itself.",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "An audience ask-for prompt: 'What did you want to be when you grew up?' This is not a game or exercise but a question posed to the audience to generate suggestions for improvisational scenes.",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "deconstruction",
+          "name": "Deconstruction",
+          "category": "long-form-theory",
+          "source": "ircwiki",
+          "lang": "en",
+          "expected": {
+            "description": "The Deconstruction is a long-form improv structure developed by Del Close and The Family. It starts with a long two-person opening scene that introduces characters and a central problem, then \"deconstructs\" that scene through thematic scenes, commentary scenes, and an accelerating run of ever-shorter callbacks, before returning to the opening scene for a final resolution.",
+            "howToPlay": "1. Opening Scene (6–8 min): A long two-person scene establishing relationship and a problem — present but not solve it.\n2. Two Thematic Scenes (2–3 min each): Scenes exploring what the opening scene was ABOUT, taking one character's wants/flaws into new contexts.\n3. Return to Opening Scene (1.5–2 min): Clarify and solidify the central theme.\n4. Five Commentary Scenes (1.5–2 min each): Game-heavy scenes that comment on what was unusual or flawed about the opening characters.\n5. Second Return to Opening (1–1.5 min): Heighten the stakes using ideas from the commentary scenes.\n6. The Run: An intense, accelerating series of ever-shorter scenes pulling tangents from earlier material at breakneck pace.\n7. Opening Scene Returns/Final (1.5–2 min): Wrap up the show, often by going back in time to before the conflict began.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "The Deconstruction is a long-form improv structure developed by Del Close and The Family. It begins with a long two-person opening scene that provides information for the rest of the piece, followed by thematic scenes exploring wants and flaws, returns to the opening scene, commentary scenes, and an intense series of ever-shorter scenes called 'The Run' before a final return to wrap up the show.",
+            "howToPlay": "1. Perform a long (6-8 minute) two-person opening scene focused on relationship and exploring a problem that is presented but not solved.\n2. Perform two thematic scenes (2-3 minutes each), each exploring what the opening scene was about by taking one character's actions and exploring their wants and flaws.\n3. Return to the opening scene (1.5-2 minutes) to clarify and solidify what the rest of the piece is about.\n4. Perform five commentary scenes (1.5-2 minutes each) that comment on what was unusual or flawed about the characters in the opening scene. These should be game-heavy, focusing on straight man vs. absurd man.\n5. Return to the opening scene again (1-1.5 minutes) to heighten the stakes using ideas from the commentary scenes.\n6. Perform 'The Run' — an intense series of ever-shorter scenes at an increasingly breakneck pace. Anything goes as long as the pace consistently picks up.\n7. Return to the opening scene for the final (1.5-2 minutes) to wrap up the show. A classic technique is to go back in time, showing the characters before their conflict began.",
+            "variations": [],
+            "tips": [
+              "The opening scene is all about relationship and exploring the problem that is presented but not solved.",
+              "Commentary scenes should be game-heavy and focus on 'bits' — straight man vs. absurd man.",
+              "In 'The Run', pace is as important, if not more important, than content.",
+              "A classic finale technique is to go back in time, showing the characters before their conflict began, creating a poignant contrast."
+            ],
+            "referencedElements": [
+              "Del Close",
+              "The Family"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "game-concept",
+          "name": "Game",
+          "category": "concept-no-howtoplay",
+          "source": "ircwiki",
+          "lang": "en",
+          "expected": {
+            "description": "\"Game\" is a foundational improv concept with distinct meanings in shortform and longform. In shortform, a game is a set of pre-determined rules governing a scene's structure. In longform, the \"game of the scene\" is the interesting or funny pattern discovered during improvisation. Finding the game involves identifying the situation, spotting the first unusual thing, and asking \"if this is true, then what else is true?\" to heighten the pattern.",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [
+              "In shortform, a game is a set of pre-determined rules that govern the general structure of any scene.",
+              "In longform, find the game by answering three questions: What is the situation? What is the first unusual thing? If this is true, then what else is true?",
+              "The situation (who, where, what) can be established very quickly — within a few lines, or even through environment and object work before anyone speaks."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Game is an improvisational concept with different meanings in shortform and longform improv. In shortform, 'game' refers to a set of pre-determined rules governing a scene's structure. In longform, 'game' describes what is interesting or funny about an improvisational scene, discovered by identifying the situation, the first unusual thing, and exploring patterns through 'if this is true, then what else is true?'",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [
+              "To find the game in a longform scene, ask three questions: What is the situation? What is the first unusual thing? If this is true, then what else is true?",
+              "The situation (who, where, what) can be established very quickly within a few lines.",
+              "The first unusual thing is the first thing a character does or says that sticks out like a sore thumb within the given situation.",
+              "Once you know what is out of the ordinary, explore and heighten that pattern by asking 'if this is true, what else is true?'"
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.3333333333333333,
+            "refRecall": 1
+          }
+        }
+      ],
+      "summary": {
+        "descOk": 15,
+        "howOk": 15,
+        "avgVarRecall": 0.9333333333333333,
+        "avgTipRecall": 0.7111111111111111,
+        "avgRefRecall": 0.9333333333333333
+      }
+    },
+    {
+      "id": "flash",
+      "label": "deepseek-v4-flash",
+      "modelId": "opencode-go/deepseek-v4-flash",
+      "results": [
+        {
+          "elementId": "freeze-tag",
+          "name": "Freeze Tag",
+          "category": "well-structured-game",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Freeze Tag is a fast-paced improv game where two players start a scene, anyone calls \"Freeze!\" to lock them in position, and a new player taps in, assumes the frozen pose, and launches an entirely new, unrelated scene. It trains spontaneity, physicality, and the core improv principle of accepting what you are given and building on it. Also known as \"Freeze\", \"Zap\", \"Chain Impro\" or \"Tap Out\".",
+            "howToPlay": "1. Two players begin a scene with full physical commitment — moving, using the space, no \"talking heads\".\n2. Any waiting player shouts \"Freeze!\" or \"Stop!\" when the stage picture is strong or interesting.\n3. Both stage players freeze instantly in their exact poses — no drift, no relaxation.\n4. A waiting player steps forward, gently taps out one frozen player, and takes over that exact pose. The tapped-out player leaves the stage.\n5. The new player immediately begins a completely new scene, justifying the pose with fresh characters, setting, and story — totally unrelated to the previous scene.\n6. Repeat until the group decides to end.",
+            "variations": [
+              {
+                "name": "Blind Freeze",
+                "description": "Waiting players stand with their backs to the stage. They call \"stop\", turn around, and must work with whatever picture they find. Prevents pre-planning and pushes pure spontaneity."
+              },
+              {
+                "name": "Elimination Freeze",
+                "description": "Competitive version. Players who hesitate, lack ideas, or stall in justification are eliminated. The last remaining player is the \"freeze king\". Works especially well in shows."
+              },
+              {
+                "name": "Object Freeze",
+                "description": "Poses must involve interaction with an invisible object. Every new scene defines what object is being held or manipulated by the body posture."
+              }
+            ],
+            "tips": [
+              "Avoid the obvious continuation — a raised arm doesn't always have to be a traffic cop. Take the idea one step further.",
+              "Give extreme and dynamic poses as gifts when you are on stage. Static standing offers no inspiration to the next player.",
+              "Time the freeze when the stage picture is especially strong or a conflict has just peaked — not too early, not too late.",
+              "Watch colleagues' poses carefully from the sideline. Inaccurate pose reproduction leads to a wooden new scene start."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Freeze Tag is an improv game where players freeze in place when someone calls 'Freeze!', and a new player takes over a pose to start a completely new scene. It is a classic warm-up and stand-alone act that trains spontaneity, physical commitment, and the 'yes, and' mindset.",
+            "howToPlay": "1. All players form a loose half-circle at the edge of the stage. Two players step out and begin a scene with full physical commitment.\n2. The two players move, use the space and react to each other. No 'talking heads'.\n3. Any waiting player can shout 'Freeze!' or 'Stop!' when the picture on stage is strong or interesting.\n4. Both stage players freeze instantly in their exact poses. No drift, no relaxation.\n5. A waiting player walks on, gently taps out one of the frozen players and takes over that exact pose.\n6. The new player justifies the pose with a completely fresh scene. Story, setting and characters have nothing to do with what came before.\n7. Repeat until the group decides to end.",
+            "variations": [
+              {
+                "name": "Blind Freeze",
+                "description": "Waiting players stand with their back to the stage and call 'stop' spontaneously, then turn and work with whatever picture they find."
+              },
+              {
+                "name": "Elimination Freeze",
+                "description": "Competitive version where anyone who hesitates or stalls is eliminated until one 'freeze king' remains."
+              },
+              {
+                "name": "Object Freeze",
+                "description": "Every pose must involve interaction with an invisible object, requiring each new scene to define an object being held or moved."
+              }
+            ],
+            "tips": [
+              "Avoid the obvious continuation — if someone is frozen with a raised arm, the policeman directing traffic is the first idea everyone has. Take it a step further.",
+              "Give extreme poses as gifts. Putting yourself in uncomfortable or dynamic positions is a wonderful gift to your colleagues.",
+              "A good freeze hits when the picture is especially strong or when a conflict has just reached its peak.",
+              "Watch carefully from the side of the stage. You need to observe how your colleagues' poses look, not just think about your own next idea."
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.75,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "half-life",
+          "name": "Half-Life",
+          "category": "inline-variant",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Half-Life (also known as Fast Forward) is an improv game where a scene is first played in one minute, then repeated in ever-shorter time frames — 30, 15, 7, 3, and finally 1 second. The rapid compression forces players to strip each repetition down to the essential beats, and the resulting slapstick effect reliably generates laughs even from weak starting material.",
+            "howToPlay": "1. Ask the audience for a dramatic situation to start the scene.\n2. Play a scene with as much action as possible — location changes, dialogue, drama.\n3. After one minute, repeat the same scene in 30 seconds, hitting all the key anchor points.\n4. Repeat again in 15 seconds, then 7, then 3, then 1 second, each time compressing to the essentials.",
+            "variations": [
+              {
+                "name": "Variable Start Length",
+                "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+              }
+            ],
+            "tips": [
+              "Ask the audience for a suggestion based on a dramatic situation — it gives the scene stakes from the start.",
+              "The starting scene should contain as much action as possible: changes of location, dialogue, drama — the more material, the funnier the compressions.",
+              "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "A scene is played within one minute and then repeated in progressively shorter time frames (30, 15, 7, 3, and 1 second), forcing players to reduce to the essentials. Even weak starting scenes become entertaining through the slapstick effect of compression.",
+            "howToPlay": "1. Ask the audience for a suggestion based on a dramatic situation.\n2. Play a one-minute scene with as much action as possible: changes of location, dialogue, drama, etc.\n3. Repeat the scene in 30 seconds.\n4. Repeat the scene in 15 seconds.\n5. Repeat the scene in 7 seconds.\n6. Repeat the scene in 3 seconds.\n7. Repeat the scene in 1 second.",
+            "variations": [
+              {
+                "name": "Variable start length",
+                "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+              }
+            ],
+            "tips": [
+              "Ask the audience for a suggestion based on a dramatic situation.",
+              "The starting scene should contain as much action as possible: changes of location, dialogue, drama, and so on.",
+              "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats."
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "yes-no",
+          "name": "Yes - No",
+          "category": "minimal-content",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Yes - No is a simple paired improv exercise where one player can only say \"Yes\" and the other only \"No\". Despite having just one word each, they carry out a full conversation using tone, volume, rhythm, pauses, and body language. Roles are swapped partway through.",
+            "howToPlay": "1. Form pairs. One player may only say \"Yes\", the other only \"No\".\n2. Have a full conversation despite the limitation, using tone, volume, rhythm, pauses, and body language to convey meaning.\n3. After a while, switch roles so each player experiences both constraints.",
+            "variations": [],
+            "tips": [
+              "Communication is mostly non-verbal — this exercise makes that vivid by restricting vocabulary to a single word each.",
+              "Use tone, volume, rhythm, and pauses to differentiate between question, statement, anger, excitement, and other meanings."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "A paired exercise where one player can only say 'Yes' and the other only 'No', forcing a full conversation using tone, volume, rhythm, pauses, and body language. After a while, roles switch to train vocal expression, status play, and awareness of non-verbal communication.",
+            "howToPlay": "1. Form pairs.\n2. One player can only say 'Yes', the other only 'No'.\n3. Have a full conversation using tone, volume, rhythm, pauses, and body language.\n4. After a while, switch roles.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "mirror-exercises",
+          "name": "Mirror Exercises",
+          "category": "short-exercise",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Mirror Exercises is a classic paired improv warm-up where two players face each other and one mirrors the other's slow movements exactly. The goal is for an outside observer to be unable to tell who is leading and who is following. It trains observation, patience, and physical synchronization.",
+            "howToPlay": "1. Two players face each other. One leads with slow, deliberate movements while the other mirrors exactly.\n2. The goal is for an observer to not be able to tell who leads.\n3. Switch roles after a while.\n4. Eventually, try leading and following simultaneously with no designated leader.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Two players face each other; one leads with slow movements while the other mirrors exactly, aiming to make it impossible for an observer to tell who leads. After switching roles, the goal is to eventually lead and follow simultaneously without a designated leader.",
+            "howToPlay": "1. Two players face each other.\n2. One leads with slow, deliberate movements.\n3. The other mirrors exactly, aiming to make it impossible for an observer to tell who leads.\n4. After a while, switch roles.\n5. Eventually, try leading and following simultaneously with no designated leader.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "talk-at-touch",
+          "name": "Talk at touch",
+          "category": "medium-game",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Talk at touch is a two-player improv game where speaking is only allowed while one player is physically touching the other, and only the player who initiated the touch may talk. Permanent contact like holding hands is prohibited. The constant alternation between mute physical play and spoken sections creates comedy from the necessity to touch in order to communicate.",
+            "howToPlay": "1. Two players perform a scene, optionally with an audience suggestion.\n2. A player may only speak while touching the other player, and only the touching player may talk.\n3. Permanent contact such as holding hands is prohibited — touch must be initiated anew each time.\n4. This produces a rhythm of mute physical sections alternating with spoken dialogue.",
+            "variations": [
+              {
+                "name": "Bidirectional Touch",
+                "description": "A touch is valid in both directions: as soon as contact exists, both players may speak regardless of who initiated it. When contact breaks, both must be silent and can only play pantomime."
+              }
+            ],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "A scene where players can only speak when one player touches the other, and only the initiator of the touch may speak. Permanent contact such as holding hands is prohibited, creating alternating mute and spoken sections with comedy arising from the necessity of touching to communicate.",
+            "howToPlay": "1. Set up a scene with two players (optional audience input).\n2. Players may only speak when one player touches the other.\n3. Only the player who initiates the touch may speak.\n4. Permanent contact such as holding hands is prohibited.\n5. When contact breaks, both must be silent and play pantomime.",
+            "variations": [
+              {
+                "name": "Bidirectional touch",
+                "description": "A touch is valid in both directions — as soon as contact is made, both may speak. As soon as contact breaks, both must be silent and can only play pantomime."
+              }
+            ],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "swinging-pendulum",
+          "name": "Swinging Pendulum of Death",
+          "category": "external-refs",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Swinging Pendulum of Death is a complex three-player improv game with strong narrative structure. Each player is given a distinct character, location, and conflict. The game cycles through three locations, with one character dying at each, then repeatedly revisits locations at random — requiring the actor who died there to drop dead instantly while the others deal with the aftermath.",
+            "howToPlay": "1. Assign each of three actors a location, a conflict, and a character.\n2. Start at the first actor's location. The other two adapt to fit that scenario. Play the scene until that actor's character dies.\n3. The judge calls a new location. The actor who just died returns as a new character. Play the scene until the second actor's character dies.\n4. Repeat for the third location until the third character dies.\n5. Once all three deaths are established, the judge calls locations at random. The actor who died in that location immediately drops dead, and the others continue the aftermath. Repeat until the game ends.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "A complex three-actor game where each actor receives a location, conflict, and character. Scenes are played at each location until the relevant character dies, then locations are called at random as characters come back to life in different roles within other scenes.",
+            "howToPlay": "1. Each of the three actors is given a location, conflict, and character by the audience.\n2. Start at the first location. Only the character associated with that location is given; the other two actors play characters consistent with that location's world.\n3. Build the scene until the character tied to that location dies.\n4. The judge calls out a new location. The actor who died comes back to life as a new character in the new location. Build the scene until the next location's character dies.\n5. Repeat for the third location.\n6. After all three deaths are established, the judge calls any location at random. The actor who died in that location immediately drops dead again; the other actors pick up the scene dealing with the aftermath.\n7. Repeat random location calls until the buzzer signals the end of the game.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "superscene",
+          "name": "Superscene",
+          "category": "long-form-show",
+          "source": "improwiki",
+          "lang": "en",
+          "expected": {
+            "description": "Superscene is a long-form improv show format for three to five players, structured as a competitive storytelling tournament. Each player acts as a director for their own story, casting the others as actors. After all directors have presented one scene, the audience votes by applause to eliminate one story each round until a single \"Superscene\" remains.",
+            "howToPlay": "1. Three to five players participate. Each takes a turn as \"director\" of their own story.\n2. The director introduces the scene, asks the audience for guidelines, and may impose additional requirements (rhyme, genre, ABC-game, etc.).\n3. The other players perform the scene. The director ends it at a chosen moment.\n4. After all directors have presented, each briefly promotes their story to the audience.\n5. The audience votes by applause on each scene. The scene with the least applause is eliminated.\n6. The remaining directors receive additional audience guidelines for the next round. Play another round without the eliminated story.\n7. Repeat until one story remains — the \"Superscene\".",
+            "variations": [],
+            "tips": [
+              "Directors should only promote their own story — never comment on or disparage others.",
+              "End each scene with a cliff-hanger to make the audience curious and invested in seeing the sequel.",
+              "The goal is to arouse and maintain the audience's interest in the progress of the story across rounds.",
+              "Despite the competitive format, this is about creative cooperation — all players should give their best in every scene, regardless of whose story it is."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Three to five players take turns directing scenes with audience guidelines. After all have directed, each director promotes their story, the audience votes to eliminate one, and the process repeats until one 'Superscene' remains.",
+            "howToPlay": "1. Three to five players each take a turn as director.\n2. The director introduces a scene, asks the audience for guidelines, and may place additional requirements (e.g., rhyme, ABC-game, genre).\n3. The other players perform the scene. The director ends the scene at a chosen time.\n4. After all have directed, each director briefly promotes their story, explaining why the audience should see its sequel.\n5. The audience votes by applause; the scene with the least applause is eliminated.\n6. Remaining directors receive additional audience guidelines. The second round proceeds the same way, excluding the eliminated story.\n7. Continue eliminating one story per round until one 'Superscene' remains.",
+            "variations": [],
+            "tips": [
+              "Directors only promote their own story; they will not comment on or disparage the others.",
+              "It is sensible to end each scene with a cliff-hanger.",
+              "The director does not cut off the continuing scene by the rules any more.",
+              "Even when the directors are (supposedly) competitors, all still try to give their best in every scene — it is about creative cooperation."
+            ],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.25,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "gefuehlspunkte",
+          "name": "Gefühlspunkte",
+          "category": "german-content",
+          "source": "improwiki",
+          "lang": "de",
+          "expected": {
+            "description": "Bei Gefühlspunkte werden zwei gut sichtbare Punkte auf die Bühne geklebt und jedem wird per Publikumszuruf ein gegensätzliches Gefühl zugeordnet (z.B. Hass und Liebe). Die Spieler improvisieren eine zusammenhängende Szene an einem vom Publikum vorgegebenen Ort, wobei sie ihre Figur je nach Nähe zu einem Gefühlspunkt in der entsprechenden Emotion einfärben — direkt auf dem Punkt erfolgt der völlige Gefühlsausbruch.",
+            "howToPlay": "1. Zwei gut sichtbare Punkte werden auf der Bühne markiert.\n2. Das Publikum ordnet jedem Punkt ein gegensätzliches Gefühl zu (z.B. Hass und Liebe, Eifersucht und Gleichgültigkeit).\n3. Das Publikum gibt einen Ort für die Szene vor.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je näher ein Spieler einem Gefühlspunkt kommt, desto stärker spielt er die entsprechende Emotion aus. Auf dem Punkt selbst erfolgt der völlige Gefühlsausbruch.",
+            "variations": [],
+            "tips": [
+              "Nicht nur die Extreme auf den Gefühlspunkten spielen, sondern auch die Abstufungen und Übergänge der Gefühle zwischen den Punkten.",
+              "Zusätzlich zum Ort kann das Publikum auch Gegenstände oder Raumdetails an den Gefühlspunkten vorgeben (z.B. ein Sessel am Hass-Punkt, ein Fernseher am Liebes-Punkt).",
+              "Größere Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich wirken."
+            ],
+            "referencedElements": [
+              "Gefühlsquadrat"
+            ]
+          },
+          "actual": {
+            "description": "Gefühlspunkte ist ein Improvisationsspiel, bei dem zwei gut sichtbare Punkte auf der Bühne mit gegensätzlichen Emotionen (z.B. Hass-Liebe) benannt werden. Die Spieler entwickeln eine Szene, wobei die Figur die Emotion umso stärker ausspielt, je näher sie dem jeweiligen Punkt kommt.",
+            "howToPlay": "1. Klebe zwei gut sichtbare Punkte auf die Bühne.\n2. Lasse dem Publikum für jeden Punkt ein gegensätzliches Gefühl zurufen (z.B. Hass-Liebe, Trauer-Freude).\n3. Lasse dem Publikum einen Ort für die Szene vorgeben.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je näher ein Spieler einem Gefühlspunkt kommt, desto stärker wird die entsprechende Emotion gespielt.\n6. Auf dem Gefühlspunkt selbst kommt es zum völligen Gefühlsausbruch.",
+            "variations": [
+              {
+                "name": "Gefühlsquadrat",
+                "description": "Ein ähnliches Spiel mit vier statt zwei Gefühlspunkten."
+              }
+            ],
+            "tips": [
+              "Spiele nicht nur die Extreme auf den Gefühlspunkten, sondern auch die Abstufungen der Gefühle zwischen diesen.",
+              "Zusätzlich zum Ort kann man sich auch Gegenstände oder Raumdetails geben lassen, die an dem betreffenden Gefühlspunkt vorhanden sind.",
+              "Die größeren Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich erscheinen."
+            ],
+            "referencedElements": [
+              "Gefühlsquadrat"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0.6666666666666666,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "distanz-schlaegerei",
+          "name": "Distanz-Schlägerei",
+          "category": "german-exercise",
+          "source": "improwiki",
+          "lang": "de",
+          "expected": {
+            "description": "Distanz-Schlägerei ist eine pantomimische Aufwärmübung, bei der zwei Spieler in sicherer Entfernung einen Kampf simulieren. Der Angreifer attackiert mit wechselnden Körperteilen aus der Distanz, der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden. Die Übung kann paarweise oder in der ganzen Gruppe gespielt werden.",
+            "howToPlay": "1. Zwei Spieler stellen sich in angemessener Entfernung gegenüber auf.\n2. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer nutzt wechselnd Füße, Arme, Kopf und Schultern, um plötzlich und immer wieder zu attackieren — stets aus sicherer Entfernung.\n3. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden.\n4. Variante: Die ganze Gruppe kämpft gleichzeitig, \"jeder gegen jeden\".",
+            "variations": [],
+            "tips": [
+              "Die Übung eignet sich gut zum Aufwärmen, zum Hemmungen- und Frust-Abbauen und trainiert den körperlichen Ausdruck.",
+              "Trotz der Distanz muss der Verteidiger überzeugend und spontan auf jeden Angriff reagieren."
+            ],
+            "referencedElements": [
+              "Zeitlupenschlägerei"
+            ]
+          },
+          "actual": {
+            "description": "Distanz-Schlägerei ist eine Aufwärmübung, bei der zwei Spieler sich gegenüberstehen und einer den anderen aus sicherer Entfernung mit Füßen, Armen, Kopf und Schulter attackiert. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden, was Hemmungen und Frust abbaut und den Ausdruck trainiert.",
+            "howToPlay": "1. Zwei Spieler stehen sich in angemessener Entfernung gegenüber.\n2. Ein Spieler ist der Angreifer, der andere der Verteidiger.\n3. Der Angreifer nutzt wechselnd Füße, Arme, Kopf, Schulter, um den Verteidiger plötzlich und immer wieder zu attackieren — stets in sicherer Entfernung.\n4. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden.",
+            "variations": [
+              {
+                "name": "Jeder gegen jeden",
+                "description": "Die ganze Gruppe kämpft gleichzeitig, jeder gegen jeden."
+              }
+            ],
+            "tips": [],
+            "referencedElements": [
+              "Zeitlupenschlägerei"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "harold-french",
+          "name": "Harold-French",
+          "category": "learnimprov-structured",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "Harold-French (also called Herald or Sheila) is a version of the Harold long-form improv format where all scenes take place in a single environment. The Harold itself is a classic structure of three sets of three scenes connected by a common theme, created by Del Close. Scene transitions are controlled by offstage ensemble members through various \"wipe\" techniques.",
+            "howToPlay": "1. Get a broad general theme from the audience (single word or phrase).\n2. The ensemble opens with a group riff on the theme — free associations, a group song, or similar.\n3. Play 3 open scenes informed by but not directly related to each other.\n4. Perform a predetermined group handle (another structured bit).\n5. Repeat this cycle 3 times total, for 9 open scenes. By the last round, stories should begin to weave together.\n6. Scene transitions are controlled by offstage members through wipes: clap, front wipe, tap out, lights dim, or coach call.",
+            "variations": [
+              {
+                "name": "Monoscene",
+                "description": "A Harold that takes place in one environment."
+              },
+              {
+                "name": "Blind Harold",
+                "description": "Participants are seated and blindfolded in the dark."
+              },
+              {
+                "name": "The Bat",
+                "description": "Unblindfolded Harold performed in the dark."
+              },
+              {
+                "name": "Armando",
+                "description": "Scenes are interceded by true story monologues from a designated monologist."
+              },
+              {
+                "name": "Triple Play",
+                "description": "3 by 3 scenes with no interceding handles."
+              }
+            ],
+            "tips": [
+              "The theme should be as broad as possible. Nouns are discouraged. For example, \"toothbrush\" could be wrangled into the theme \"cleaning\".",
+              "A smart group will put their best storyteller as their balladeer, not the best singer."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "The French Harold is a Harold that takes place in one environment. It consists of 3 sets of 3 scenes connected by a common theme, with transitions determined by offstage ensemble members rather than a booth.",
+            "howToPlay": "1. Get a general theme from the audience.\n2. Start with free associations or a group song riffing off the theme.\n3. Play 3 open scenes not related to each other but informed by the theme.\n4. Play another handle (group piece).\n5. Repeat the cycle (free association → 3 scenes → handle) for 3 total cycles, producing 9 open scenes.\n6. By the last round, stories start to weave together. Transitions between scenes are determined by offstage ensemble members (wipes), not called by a booth.",
+            "variations": [
+              {
+                "name": "Monoscene",
+                "description": "A Harold in one environment without cuts."
+              },
+              {
+                "name": "Blind Harold",
+                "description": "Performed blindfolded in the dark."
+              },
+              {
+                "name": "The Bat",
+                "description": "Unblindfolded Harold performed in the dark."
+              },
+              {
+                "name": "Armando",
+                "description": "Scenes interceded by true story monologues."
+              },
+              {
+                "name": "Sybil",
+                "description": "Performed by a single performer."
+              },
+              {
+                "name": "The Narce",
+                "description": "Single-performer Harold."
+              },
+              {
+                "name": "Triple Play",
+                "description": "3 by 3 scenes with no interceding handles."
+              }
+            ],
+            "tips": [],
+            "referencedElements": [
+              "Harold"
+            ]
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "balladeer-doo-wop",
+          "name": "Balladeer-Doo Wop",
+          "category": "musical-form",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "Balladeer-Doo Wop (also known as Minstrel or Musical MC) is a long-form musical improv structure directed by a singing balladeer. The accompanist and singer introduce characters, locations, or events through short songs while actors perform silently on stage. The ballads control scene changes, rescues, and closures — there are no blackouts.",
+            "howToPlay": "1. An accompanist and singer (the balladeer) start with a short song (30–60 seconds) introducing a character, location, or foreshadowing an event.\n2. While the balladeer sings, players act on stage silently. When the ballad ends, they begin speaking.\n3. The balladeer uses subsequent ballads to change scenes, rescue struggling scenes, or bring scenes to a conclusion.\n4. No blackouts — all scene transitions are controlled by the balladeer.\n5. Each ballad can use a different musical genre: rap, rock, opera, etc.",
+            "variations": [
+              {
+                "name": "Doo Wop",
+                "description": "The balladeer is replaced by a group song in the style of Doo Wop. The group song can be any form of group make-a-song — Hoe Down, March Song, Madrigal, or Chant."
+              }
+            ],
+            "tips": [
+              "Put your best storyteller as the balladeer, not necessarily the best singer.",
+              "If the balladeer gets into trouble, the players must step in with a scene to recover.",
+              "Musical bits should be short — thirty seconds to a minute is usually enough to pass on story information."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "A balladeer directs an improvised piece with short musical songs (30-60 seconds) that introduce characters, locations, or foreshadow events while players act silently on-stage. The ballad is used to change scenes, rescue struggling scenes, or bring closure.",
+            "howToPlay": "1. The accompanist and singer start with a short song (30-60 seconds) introducing a character, location, or foreshadowing an event.\n2. Players act silently on-stage during the ballad.\n3. Players start to vocalize as the ballad ends.\n4. The ballad is used to change scenes, rescue a struggling scene, or bring closure to a scene that has reached a conclusion.\n5. No blackouts — all changes are made by the balladeer.\n6. A new musical genre (rap, rock, opera) can be used for each new ballad.\n7. If the balladeer gets into trouble, the players step in with a scene.",
+            "variations": [
+              {
+                "name": "Doo Wop",
+                "description": "The balladeer is replaced by a group song in the style of Doo Wop or any group make-a-song format (Hoe Down, March Song, Madrigal, Chant)."
+              }
+            ],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "translation-healthcare",
+          "name": "Translation-Healthcare",
+          "category": "handle-overlay",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "Translation-Healthcare is a handle overlaid on an open scene where a translator facilitates a healthcare interaction between a provider and a patient who speaks a made-up gibberish language. Unlike typical translation scenes, the translation is performed for another character on stage — not the audience — so the audience observes both sides. The format emphasizes character work, narrative arc, and avoiding cultural stereotypes.",
+            "howToPlay": "1. A host sets up a non-existent gibberish language (robot, economist, whale, toaster, etc.) and the healthcare scenario.\n2. One performer plays the patient speaking gibberish. Another plays the healthcare provider. A third translates between them.\n3. The patient communicates in gibberish with full physicality, emotion, and want; the translator interprets for the provider, and vice versa.\n4. Performers maintain a narrative arc exploring the healthcare interaction — not just the translation gimmick.",
+            "variations": [
+              {
+                "name": "Translated Opera",
+                "description": "As described, with the gibberish sung."
+              },
+              {
+                "name": "Translated Film",
+                "description": "As described, using movie thematics."
+              },
+              {
+                "name": "Bad Translator",
+                "description": "Real language translated by a non-speaker of that language."
+              },
+              {
+                "name": "Mechanical Translator",
+                "description": "Real language translated using Google Translate or similar."
+              },
+              {
+                "name": "Future In Laws",
+                "description": "Meet the parents/in-laws through a translator."
+              }
+            ],
+            "tips": [
+              "Set up a non-existent language (robot, economist, whale) rather than using gibberish for real languages, which can lead to stereotyping.",
+              "Create complete characters with movement and wants — don't let the translation gimmick replace the narrative arc.",
+              "Short translation for long gibberish (or vice versa) is a classic comedy gimmick."
+            ],
+            "referencedElements": [
+              "Gibberish"
+            ]
+          },
+          "actual": {
+            "description": "A handle where a translator facilitates a healthcare interaction with a patient who speaks a non-existent gibberish language. The translation is performed for another performer while the audience observes, requiring complete characters with movement and wants beyond the gibberish.",
+            "howToPlay": "1. The host sets up a non-existent language (e.g., robot, economist, whale, toaster) — avoid gibberish for existing languages to prevent stereotyping.\n2. One performer plays the patient speaking gibberish.\n3. Another performer plays the translator facilitating the healthcare interaction.\n4. All performers create complete characters with movement and wants in addition to the gibberish.\n5. Maintain a narrative arc that explores the healthcare interaction.\n6. Use gimmicks such as short translation for long gibberish, problems with idioms, differences in emotional content, or dirty words.",
+            "variations": [
+              {
+                "name": "Translated Opera",
+                "description": "Singing gibberish in an operatic style."
+              },
+              {
+                "name": "Translated Film",
+                "description": "Translation handle with movie thematics."
+              },
+              {
+                "name": "Bad Translator",
+                "description": "A real language translated by a non-speaker."
+              },
+              {
+                "name": "Mechanical Translator",
+                "description": "Using Google Translate as the translator."
+              },
+              {
+                "name": "Future In Laws",
+                "description": "Meet-the-parents or meet-the-in-laws scenario with translation."
+              }
+            ],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0,
+            "refRecall": 0
+          }
+        },
+        {
+          "elementId": "what-did-you-want",
+          "name": "What did you want to be when you grew up?",
+          "category": "ask-for-edge",
+          "source": "learnimprov",
+          "lang": "en",
+          "expected": {
+            "description": "\"What did you want to be when you grew up?\" is an audience ask-for prompt from learnimprov.com. It is a question used to solicit suggestions from the audience to inspire an improv scene, not a game or exercise in itself.",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "An audience ask-for prompt used to gather suggestions at the start of a scene or show.",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "deconstruction",
+          "name": "Deconstruction",
+          "category": "long-form-theory",
+          "source": "ircwiki",
+          "lang": "en",
+          "expected": {
+            "description": "The Deconstruction is a long-form improv structure developed by Del Close and The Family. It starts with a long two-person opening scene that introduces characters and a central problem, then \"deconstructs\" that scene through thematic scenes, commentary scenes, and an accelerating run of ever-shorter callbacks, before returning to the opening scene for a final resolution.",
+            "howToPlay": "1. Opening Scene (6–8 min): A long two-person scene establishing relationship and a problem — present but not solve it.\n2. Two Thematic Scenes (2–3 min each): Scenes exploring what the opening scene was ABOUT, taking one character's wants/flaws into new contexts.\n3. Return to Opening Scene (1.5–2 min): Clarify and solidify the central theme.\n4. Five Commentary Scenes (1.5–2 min each): Game-heavy scenes that comment on what was unusual or flawed about the opening characters.\n5. Second Return to Opening (1–1.5 min): Heighten the stakes using ideas from the commentary scenes.\n6. The Run: An intense, accelerating series of ever-shorter scenes pulling tangents from earlier material at breakneck pace.\n7. Opening Scene Returns/Final (1.5–2 min): Wrap up the show, often by going back in time to before the conflict began.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "A long form structure developed by Del Close featuring an opening scene, thematic scenes exploring what the scene was about, commentary scenes on character flaws, and a rapid concluding 'Run' leading to a final return to the opening scene.",
+            "howToPlay": "1. Play a long (6-8 minute) two-person opening scene focused on relationship and presenting an unresolved problem.\n2. Follow with two thematic scenes (2-3 minutes each), each exploring what the opening scene was about by examining one character's wants or flaws.\n3. Return to the opening scene (1.5-2 minutes) to clarify and solidify what the rest of the piece is about.\n4. Play five commentary scenes (1.5-2 minutes each) commenting on what was unusual or flawed about the opening characters. Focus on 'bits' — straight man vs. absurd man.\n5. Return to the opening scene again (1-1.5 minutes) to heighten the stakes using ideas from the commentary scenes.\n6. Play 'The Run' — an intense series of ever-shorter scenes where pace is as important as content. Anything goes; consistently pick up the pace until reaching a breakneck speed.\n7. Return to the opening scene for the finale (1.5-2 minutes). A classic technique is to go back in time, showing the characters before their conflict began.",
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 1,
+            "refRecall": 1
+          }
+        },
+        {
+          "elementId": "game-concept",
+          "name": "Game",
+          "category": "concept-no-howtoplay",
+          "source": "ircwiki",
+          "lang": "en",
+          "expected": {
+            "description": "\"Game\" is a foundational improv concept with distinct meanings in shortform and longform. In shortform, a game is a set of pre-determined rules governing a scene's structure. In longform, the \"game of the scene\" is the interesting or funny pattern discovered during improvisation. Finding the game involves identifying the situation, spotting the first unusual thing, and asking \"if this is true, then what else is true?\" to heighten the pattern.",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [
+              "In shortform, a game is a set of pre-determined rules that govern the general structure of any scene.",
+              "In longform, find the game by answering three questions: What is the situation? What is the first unusual thing? If this is true, then what else is true?",
+              "The situation (who, where, what) can be established very quickly — within a few lines, or even through environment and object work before anyone speaks."
+            ],
+            "referencedElements": []
+          },
+          "actual": {
+            "description": "Game is an improvisational concept used differently in shortform (pre-determined rules governing scene structure) and longform (what makes a scene interesting or funny). Finding the game involves identifying the situation, the first unusual thing, and asking 'if this is true, what else is true?' to explore and heighten a pattern of behavior.",
+            "howToPlay": null,
+            "variations": [],
+            "tips": [],
+            "referencedElements": []
+          },
+          "scores": {
+            "descOk": true,
+            "howToPlayOk": true,
+            "varCountMatch": true,
+            "varRecall": 1,
+            "tipRecall": 0,
+            "refRecall": 1
+          }
+        }
+      ],
+      "summary": {
+        "descOk": 15,
+        "howOk": 15,
+        "avgVarRecall": 1,
+        "avgTipRecall": 0.5111111111111112,
+        "avgRefRecall": 0.9333333333333333
+      }
+    }
+  ]
+}

--- a/src/normalize/__testdata__/results/flash-results.json
+++ b/src/normalize/__testdata__/results/flash-results.json
@@ -1,0 +1,677 @@
+{
+  "meta": {
+    "model": "deepseek-v4-flash",
+    "modelId": "opencode-go/deepseek-v4-flash",
+    "opencodeVersion": "1.15.5",
+    "timestamp": "2026-06-03T16:52:27.640Z",
+    "runId": "2026-06-03T16-52-27-640Z",
+    "elementCount": 15,
+    "promptChars": 21166,
+    "outputChars": 17139,
+    "elapsedSeconds": 81.1
+  },
+  "results": [
+    {
+      "elementId": "freeze-tag",
+      "name": "Freeze Tag",
+      "category": "well-structured-game",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Freeze Tag is a fast-paced improv game where two players start a scene, anyone calls \"Freeze!\" to lock them in position, and a new player taps in, assumes the frozen pose, and launches an entirely new, unrelated scene. It trains spontaneity, physicality, and the core improv principle of accepting what you are given and building on it. Also known as \"Freeze\", \"Zap\", \"Chain Impro\" or \"Tap Out\".",
+        "howToPlay": "1. Two players begin a scene with full physical commitment — moving, using the space, no \"talking heads\".\n2. Any waiting player shouts \"Freeze!\" or \"Stop!\" when the stage picture is strong or interesting.\n3. Both stage players freeze instantly in their exact poses — no drift, no relaxation.\n4. A waiting player steps forward, gently taps out one frozen player, and takes over that exact pose. The tapped-out player leaves the stage.\n5. The new player immediately begins a completely new scene, justifying the pose with fresh characters, setting, and story — totally unrelated to the previous scene.\n6. Repeat until the group decides to end.",
+        "variations": [
+          {
+            "name": "Blind Freeze",
+            "description": "Waiting players stand with their backs to the stage. They call \"stop\", turn around, and must work with whatever picture they find. Prevents pre-planning and pushes pure spontaneity."
+          },
+          {
+            "name": "Elimination Freeze",
+            "description": "Competitive version. Players who hesitate, lack ideas, or stall in justification are eliminated. The last remaining player is the \"freeze king\". Works especially well in shows."
+          },
+          {
+            "name": "Object Freeze",
+            "description": "Poses must involve interaction with an invisible object. Every new scene defines what object is being held or manipulated by the body posture."
+          }
+        ],
+        "tips": [
+          "Avoid the obvious continuation — a raised arm doesn't always have to be a traffic cop. Take the idea one step further.",
+          "Give extreme and dynamic poses as gifts when you are on stage. Static standing offers no inspiration to the next player.",
+          "Time the freeze when the stage picture is especially strong or a conflict has just peaked — not too early, not too late.",
+          "Watch colleagues' poses carefully from the sideline. Inaccurate pose reproduction leads to a wooden new scene start."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Freeze Tag is an improv game where players freeze in place when someone calls 'Freeze!', and a new player takes over a pose to start a completely new scene. It is a classic warm-up and stand-alone act that trains spontaneity, physical commitment, and the 'yes, and' mindset.",
+        "howToPlay": "1. All players form a loose half-circle at the edge of the stage. Two players step out and begin a scene with full physical commitment.\n2. The two players move, use the space and react to each other. No 'talking heads'.\n3. Any waiting player can shout 'Freeze!' or 'Stop!' when the picture on stage is strong or interesting.\n4. Both stage players freeze instantly in their exact poses. No drift, no relaxation.\n5. A waiting player walks on, gently taps out one of the frozen players and takes over that exact pose.\n6. The new player justifies the pose with a completely fresh scene. Story, setting and characters have nothing to do with what came before.\n7. Repeat until the group decides to end.",
+        "variations": [
+          {
+            "name": "Blind Freeze",
+            "description": "Waiting players stand with their back to the stage and call 'stop' spontaneously, then turn and work with whatever picture they find."
+          },
+          {
+            "name": "Elimination Freeze",
+            "description": "Competitive version where anyone who hesitates or stalls is eliminated until one 'freeze king' remains."
+          },
+          {
+            "name": "Object Freeze",
+            "description": "Every pose must involve interaction with an invisible object, requiring each new scene to define an object being held or moved."
+          }
+        ],
+        "tips": [
+          "Avoid the obvious continuation — if someone is frozen with a raised arm, the policeman directing traffic is the first idea everyone has. Take it a step further.",
+          "Give extreme poses as gifts. Putting yourself in uncomfortable or dynamic positions is a wonderful gift to your colleagues.",
+          "A good freeze hits when the picture is especially strong or when a conflict has just reached its peak.",
+          "Watch carefully from the side of the stage. You need to observe how your colleagues' poses look, not just think about your own next idea."
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.75,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "half-life",
+      "name": "Half-Life",
+      "category": "inline-variant",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Half-Life (also known as Fast Forward) is an improv game where a scene is first played in one minute, then repeated in ever-shorter time frames — 30, 15, 7, 3, and finally 1 second. The rapid compression forces players to strip each repetition down to the essential beats, and the resulting slapstick effect reliably generates laughs even from weak starting material.",
+        "howToPlay": "1. Ask the audience for a dramatic situation to start the scene.\n2. Play a scene with as much action as possible — location changes, dialogue, drama.\n3. After one minute, repeat the same scene in 30 seconds, hitting all the key anchor points.\n4. Repeat again in 15 seconds, then 7, then 3, then 1 second, each time compressing to the essentials.",
+        "variations": [
+          {
+            "name": "Variable Start Length",
+            "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+          }
+        ],
+        "tips": [
+          "Ask the audience for a suggestion based on a dramatic situation — it gives the scene stakes from the start.",
+          "The starting scene should contain as much action as possible: changes of location, dialogue, drama — the more material, the funnier the compressions.",
+          "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "A scene is played within one minute and then repeated in progressively shorter time frames (30, 15, 7, 3, and 1 second), forcing players to reduce to the essentials. Even weak starting scenes become entertaining through the slapstick effect of compression.",
+        "howToPlay": "1. Ask the audience for a suggestion based on a dramatic situation.\n2. Play a one-minute scene with as much action as possible: changes of location, dialogue, drama, etc.\n3. Repeat the scene in 30 seconds.\n4. Repeat the scene in 15 seconds.\n5. Repeat the scene in 7 seconds.\n6. Repeat the scene in 3 seconds.\n7. Repeat the scene in 1 second.",
+        "variations": [
+          {
+            "name": "Variable start length",
+            "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+          }
+        ],
+        "tips": [
+          "Ask the audience for a suggestion based on a dramatic situation.",
+          "The starting scene should contain as much action as possible: changes of location, dialogue, drama, and so on.",
+          "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats."
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "yes-no",
+      "name": "Yes - No",
+      "category": "minimal-content",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Yes - No is a simple paired improv exercise where one player can only say \"Yes\" and the other only \"No\". Despite having just one word each, they carry out a full conversation using tone, volume, rhythm, pauses, and body language. Roles are swapped partway through.",
+        "howToPlay": "1. Form pairs. One player may only say \"Yes\", the other only \"No\".\n2. Have a full conversation despite the limitation, using tone, volume, rhythm, pauses, and body language to convey meaning.\n3. After a while, switch roles so each player experiences both constraints.",
+        "variations": [],
+        "tips": [
+          "Communication is mostly non-verbal — this exercise makes that vivid by restricting vocabulary to a single word each.",
+          "Use tone, volume, rhythm, and pauses to differentiate between question, statement, anger, excitement, and other meanings."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "A paired exercise where one player can only say 'Yes' and the other only 'No', forcing a full conversation using tone, volume, rhythm, pauses, and body language. After a while, roles switch to train vocal expression, status play, and awareness of non-verbal communication.",
+        "howToPlay": "1. Form pairs.\n2. One player can only say 'Yes', the other only 'No'.\n3. Have a full conversation using tone, volume, rhythm, pauses, and body language.\n4. After a while, switch roles.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "mirror-exercises",
+      "name": "Mirror Exercises",
+      "category": "short-exercise",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Mirror Exercises is a classic paired improv warm-up where two players face each other and one mirrors the other's slow movements exactly. The goal is for an outside observer to be unable to tell who is leading and who is following. It trains observation, patience, and physical synchronization.",
+        "howToPlay": "1. Two players face each other. One leads with slow, deliberate movements while the other mirrors exactly.\n2. The goal is for an observer to not be able to tell who leads.\n3. Switch roles after a while.\n4. Eventually, try leading and following simultaneously with no designated leader.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Two players face each other; one leads with slow movements while the other mirrors exactly, aiming to make it impossible for an observer to tell who leads. After switching roles, the goal is to eventually lead and follow simultaneously without a designated leader.",
+        "howToPlay": "1. Two players face each other.\n2. One leads with slow, deliberate movements.\n3. The other mirrors exactly, aiming to make it impossible for an observer to tell who leads.\n4. After a while, switch roles.\n5. Eventually, try leading and following simultaneously with no designated leader.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "talk-at-touch",
+      "name": "Talk at touch",
+      "category": "medium-game",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Talk at touch is a two-player improv game where speaking is only allowed while one player is physically touching the other, and only the player who initiated the touch may talk. Permanent contact like holding hands is prohibited. The constant alternation between mute physical play and spoken sections creates comedy from the necessity to touch in order to communicate.",
+        "howToPlay": "1. Two players perform a scene, optionally with an audience suggestion.\n2. A player may only speak while touching the other player, and only the touching player may talk.\n3. Permanent contact such as holding hands is prohibited — touch must be initiated anew each time.\n4. This produces a rhythm of mute physical sections alternating with spoken dialogue.",
+        "variations": [
+          {
+            "name": "Bidirectional Touch",
+            "description": "A touch is valid in both directions: as soon as contact exists, both players may speak regardless of who initiated it. When contact breaks, both must be silent and can only play pantomime."
+          }
+        ],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "A scene where players can only speak when one player touches the other, and only the initiator of the touch may speak. Permanent contact such as holding hands is prohibited, creating alternating mute and spoken sections with comedy arising from the necessity of touching to communicate.",
+        "howToPlay": "1. Set up a scene with two players (optional audience input).\n2. Players may only speak when one player touches the other.\n3. Only the player who initiates the touch may speak.\n4. Permanent contact such as holding hands is prohibited.\n5. When contact breaks, both must be silent and play pantomime.",
+        "variations": [
+          {
+            "name": "Bidirectional touch",
+            "description": "A touch is valid in both directions — as soon as contact is made, both may speak. As soon as contact breaks, both must be silent and can only play pantomime."
+          }
+        ],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "swinging-pendulum",
+      "name": "Swinging Pendulum of Death",
+      "category": "external-refs",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Swinging Pendulum of Death is a complex three-player improv game with strong narrative structure. Each player is given a distinct character, location, and conflict. The game cycles through three locations, with one character dying at each, then repeatedly revisits locations at random — requiring the actor who died there to drop dead instantly while the others deal with the aftermath.",
+        "howToPlay": "1. Assign each of three actors a location, a conflict, and a character.\n2. Start at the first actor's location. The other two adapt to fit that scenario. Play the scene until that actor's character dies.\n3. The judge calls a new location. The actor who just died returns as a new character. Play the scene until the second actor's character dies.\n4. Repeat for the third location until the third character dies.\n5. Once all three deaths are established, the judge calls locations at random. The actor who died in that location immediately drops dead, and the others continue the aftermath. Repeat until the game ends.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "A complex three-actor game where each actor receives a location, conflict, and character. Scenes are played at each location until the relevant character dies, then locations are called at random as characters come back to life in different roles within other scenes.",
+        "howToPlay": "1. Each of the three actors is given a location, conflict, and character by the audience.\n2. Start at the first location. Only the character associated with that location is given; the other two actors play characters consistent with that location's world.\n3. Build the scene until the character tied to that location dies.\n4. The judge calls out a new location. The actor who died comes back to life as a new character in the new location. Build the scene until the next location's character dies.\n5. Repeat for the third location.\n6. After all three deaths are established, the judge calls any location at random. The actor who died in that location immediately drops dead again; the other actors pick up the scene dealing with the aftermath.\n7. Repeat random location calls until the buzzer signals the end of the game.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "superscene",
+      "name": "Superscene",
+      "category": "long-form-show",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Superscene is a long-form improv show format for three to five players, structured as a competitive storytelling tournament. Each player acts as a director for their own story, casting the others as actors. After all directors have presented one scene, the audience votes by applause to eliminate one story each round until a single \"Superscene\" remains.",
+        "howToPlay": "1. Three to five players participate. Each takes a turn as \"director\" of their own story.\n2. The director introduces the scene, asks the audience for guidelines, and may impose additional requirements (rhyme, genre, ABC-game, etc.).\n3. The other players perform the scene. The director ends it at a chosen moment.\n4. After all directors have presented, each briefly promotes their story to the audience.\n5. The audience votes by applause on each scene. The scene with the least applause is eliminated.\n6. The remaining directors receive additional audience guidelines for the next round. Play another round without the eliminated story.\n7. Repeat until one story remains — the \"Superscene\".",
+        "variations": [],
+        "tips": [
+          "Directors should only promote their own story — never comment on or disparage others.",
+          "End each scene with a cliff-hanger to make the audience curious and invested in seeing the sequel.",
+          "The goal is to arouse and maintain the audience's interest in the progress of the story across rounds.",
+          "Despite the competitive format, this is about creative cooperation — all players should give their best in every scene, regardless of whose story it is."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Three to five players take turns directing scenes with audience guidelines. After all have directed, each director promotes their story, the audience votes to eliminate one, and the process repeats until one 'Superscene' remains.",
+        "howToPlay": "1. Three to five players each take a turn as director.\n2. The director introduces a scene, asks the audience for guidelines, and may place additional requirements (e.g., rhyme, ABC-game, genre).\n3. The other players perform the scene. The director ends the scene at a chosen time.\n4. After all have directed, each director briefly promotes their story, explaining why the audience should see its sequel.\n5. The audience votes by applause; the scene with the least applause is eliminated.\n6. Remaining directors receive additional audience guidelines. The second round proceeds the same way, excluding the eliminated story.\n7. Continue eliminating one story per round until one 'Superscene' remains.",
+        "variations": [],
+        "tips": [
+          "Directors only promote their own story; they will not comment on or disparage the others.",
+          "It is sensible to end each scene with a cliff-hanger.",
+          "The director does not cut off the continuing scene by the rules any more.",
+          "Even when the directors are (supposedly) competitors, all still try to give their best in every scene — it is about creative cooperation."
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.25,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "gefuehlspunkte",
+      "name": "Gefühlspunkte",
+      "category": "german-content",
+      "source": "improwiki",
+      "lang": "de",
+      "expected": {
+        "description": "Bei Gefühlspunkte werden zwei gut sichtbare Punkte auf die Bühne geklebt und jedem wird per Publikumszuruf ein gegensätzliches Gefühl zugeordnet (z.B. Hass und Liebe). Die Spieler improvisieren eine zusammenhängende Szene an einem vom Publikum vorgegebenen Ort, wobei sie ihre Figur je nach Nähe zu einem Gefühlspunkt in der entsprechenden Emotion einfärben — direkt auf dem Punkt erfolgt der völlige Gefühlsausbruch.",
+        "howToPlay": "1. Zwei gut sichtbare Punkte werden auf der Bühne markiert.\n2. Das Publikum ordnet jedem Punkt ein gegensätzliches Gefühl zu (z.B. Hass und Liebe, Eifersucht und Gleichgültigkeit).\n3. Das Publikum gibt einen Ort für die Szene vor.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je näher ein Spieler einem Gefühlspunkt kommt, desto stärker spielt er die entsprechende Emotion aus. Auf dem Punkt selbst erfolgt der völlige Gefühlsausbruch.",
+        "variations": [],
+        "tips": [
+          "Nicht nur die Extreme auf den Gefühlspunkten spielen, sondern auch die Abstufungen und Übergänge der Gefühle zwischen den Punkten.",
+          "Zusätzlich zum Ort kann das Publikum auch Gegenstände oder Raumdetails an den Gefühlspunkten vorgeben (z.B. ein Sessel am Hass-Punkt, ein Fernseher am Liebes-Punkt).",
+          "Größere Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich wirken."
+        ],
+        "referencedElements": [
+          "Gefühlsquadrat"
+        ]
+      },
+      "actual": {
+        "description": "Gefühlspunkte ist ein Improvisationsspiel, bei dem zwei gut sichtbare Punkte auf der Bühne mit gegensätzlichen Emotionen (z.B. Hass-Liebe) benannt werden. Die Spieler entwickeln eine Szene, wobei die Figur die Emotion umso stärker ausspielt, je näher sie dem jeweiligen Punkt kommt.",
+        "howToPlay": "1. Klebe zwei gut sichtbare Punkte auf die Bühne.\n2. Lasse dem Publikum für jeden Punkt ein gegensätzliches Gefühl zurufen (z.B. Hass-Liebe, Trauer-Freude).\n3. Lasse dem Publikum einen Ort für die Szene vorgeben.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je näher ein Spieler einem Gefühlspunkt kommt, desto stärker wird die entsprechende Emotion gespielt.\n6. Auf dem Gefühlspunkt selbst kommt es zum völligen Gefühlsausbruch.",
+        "variations": [
+          {
+            "name": "Gefühlsquadrat",
+            "description": "Ein ähnliches Spiel mit vier statt zwei Gefühlspunkten."
+          }
+        ],
+        "tips": [
+          "Spiele nicht nur die Extreme auf den Gefühlspunkten, sondern auch die Abstufungen der Gefühle zwischen diesen.",
+          "Zusätzlich zum Ort kann man sich auch Gegenstände oder Raumdetails geben lassen, die an dem betreffenden Gefühlspunkt vorhanden sind.",
+          "Die größeren Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich erscheinen."
+        ],
+        "referencedElements": [
+          "Gefühlsquadrat"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.6666666666666666,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "distanz-schlaegerei",
+      "name": "Distanz-Schlägerei",
+      "category": "german-exercise",
+      "source": "improwiki",
+      "lang": "de",
+      "expected": {
+        "description": "Distanz-Schlägerei ist eine pantomimische Aufwärmübung, bei der zwei Spieler in sicherer Entfernung einen Kampf simulieren. Der Angreifer attackiert mit wechselnden Körperteilen aus der Distanz, der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden. Die Übung kann paarweise oder in der ganzen Gruppe gespielt werden.",
+        "howToPlay": "1. Zwei Spieler stellen sich in angemessener Entfernung gegenüber auf.\n2. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer nutzt wechselnd Füße, Arme, Kopf und Schultern, um plötzlich und immer wieder zu attackieren — stets aus sicherer Entfernung.\n3. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden.\n4. Variante: Die ganze Gruppe kämpft gleichzeitig, \"jeder gegen jeden\".",
+        "variations": [],
+        "tips": [
+          "Die Übung eignet sich gut zum Aufwärmen, zum Hemmungen- und Frust-Abbauen und trainiert den körperlichen Ausdruck.",
+          "Trotz der Distanz muss der Verteidiger überzeugend und spontan auf jeden Angriff reagieren."
+        ],
+        "referencedElements": [
+          "Zeitlupenschlägerei"
+        ]
+      },
+      "actual": {
+        "description": "Distanz-Schlägerei ist eine Aufwärmübung, bei der zwei Spieler sich gegenüberstehen und einer den anderen aus sicherer Entfernung mit Füßen, Armen, Kopf und Schulter attackiert. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden, was Hemmungen und Frust abbaut und den Ausdruck trainiert.",
+        "howToPlay": "1. Zwei Spieler stehen sich in angemessener Entfernung gegenüber.\n2. Ein Spieler ist der Angreifer, der andere der Verteidiger.\n3. Der Angreifer nutzt wechselnd Füße, Arme, Kopf, Schulter, um den Verteidiger plötzlich und immer wieder zu attackieren — stets in sicherer Entfernung.\n4. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden.",
+        "variations": [
+          {
+            "name": "Jeder gegen jeden",
+            "description": "Die ganze Gruppe kämpft gleichzeitig, jeder gegen jeden."
+          }
+        ],
+        "tips": [],
+        "referencedElements": [
+          "Zeitlupenschlägerei"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "harold-french",
+      "name": "Harold-French",
+      "category": "learnimprov-structured",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "Harold-French (also called Herald or Sheila) is a version of the Harold long-form improv format where all scenes take place in a single environment. The Harold itself is a classic structure of three sets of three scenes connected by a common theme, created by Del Close. Scene transitions are controlled by offstage ensemble members through various \"wipe\" techniques.",
+        "howToPlay": "1. Get a broad general theme from the audience (single word or phrase).\n2. The ensemble opens with a group riff on the theme — free associations, a group song, or similar.\n3. Play 3 open scenes informed by but not directly related to each other.\n4. Perform a predetermined group handle (another structured bit).\n5. Repeat this cycle 3 times total, for 9 open scenes. By the last round, stories should begin to weave together.\n6. Scene transitions are controlled by offstage members through wipes: clap, front wipe, tap out, lights dim, or coach call.",
+        "variations": [
+          {
+            "name": "Monoscene",
+            "description": "A Harold that takes place in one environment."
+          },
+          {
+            "name": "Blind Harold",
+            "description": "Participants are seated and blindfolded in the dark."
+          },
+          {
+            "name": "The Bat",
+            "description": "Unblindfolded Harold performed in the dark."
+          },
+          {
+            "name": "Armando",
+            "description": "Scenes are interceded by true story monologues from a designated monologist."
+          },
+          {
+            "name": "Triple Play",
+            "description": "3 by 3 scenes with no interceding handles."
+          }
+        ],
+        "tips": [
+          "The theme should be as broad as possible. Nouns are discouraged. For example, \"toothbrush\" could be wrangled into the theme \"cleaning\".",
+          "A smart group will put their best storyteller as their balladeer, not the best singer."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "The French Harold is a Harold that takes place in one environment. It consists of 3 sets of 3 scenes connected by a common theme, with transitions determined by offstage ensemble members rather than a booth.",
+        "howToPlay": "1. Get a general theme from the audience.\n2. Start with free associations or a group song riffing off the theme.\n3. Play 3 open scenes not related to each other but informed by the theme.\n4. Play another handle (group piece).\n5. Repeat the cycle (free association → 3 scenes → handle) for 3 total cycles, producing 9 open scenes.\n6. By the last round, stories start to weave together. Transitions between scenes are determined by offstage ensemble members (wipes), not called by a booth.",
+        "variations": [
+          {
+            "name": "Monoscene",
+            "description": "A Harold in one environment without cuts."
+          },
+          {
+            "name": "Blind Harold",
+            "description": "Performed blindfolded in the dark."
+          },
+          {
+            "name": "The Bat",
+            "description": "Unblindfolded Harold performed in the dark."
+          },
+          {
+            "name": "Armando",
+            "description": "Scenes interceded by true story monologues."
+          },
+          {
+            "name": "Sybil",
+            "description": "Performed by a single performer."
+          },
+          {
+            "name": "The Narce",
+            "description": "Single-performer Harold."
+          },
+          {
+            "name": "Triple Play",
+            "description": "3 by 3 scenes with no interceding handles."
+          }
+        ],
+        "tips": [],
+        "referencedElements": [
+          "Harold"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "balladeer-doo-wop",
+      "name": "Balladeer-Doo Wop",
+      "category": "musical-form",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "Balladeer-Doo Wop (also known as Minstrel or Musical MC) is a long-form musical improv structure directed by a singing balladeer. The accompanist and singer introduce characters, locations, or events through short songs while actors perform silently on stage. The ballads control scene changes, rescues, and closures — there are no blackouts.",
+        "howToPlay": "1. An accompanist and singer (the balladeer) start with a short song (30–60 seconds) introducing a character, location, or foreshadowing an event.\n2. While the balladeer sings, players act on stage silently. When the ballad ends, they begin speaking.\n3. The balladeer uses subsequent ballads to change scenes, rescue struggling scenes, or bring scenes to a conclusion.\n4. No blackouts — all scene transitions are controlled by the balladeer.\n5. Each ballad can use a different musical genre: rap, rock, opera, etc.",
+        "variations": [
+          {
+            "name": "Doo Wop",
+            "description": "The balladeer is replaced by a group song in the style of Doo Wop. The group song can be any form of group make-a-song — Hoe Down, March Song, Madrigal, or Chant."
+          }
+        ],
+        "tips": [
+          "Put your best storyteller as the balladeer, not necessarily the best singer.",
+          "If the balladeer gets into trouble, the players must step in with a scene to recover.",
+          "Musical bits should be short — thirty seconds to a minute is usually enough to pass on story information."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "A balladeer directs an improvised piece with short musical songs (30-60 seconds) that introduce characters, locations, or foreshadow events while players act silently on-stage. The ballad is used to change scenes, rescue struggling scenes, or bring closure.",
+        "howToPlay": "1. The accompanist and singer start with a short song (30-60 seconds) introducing a character, location, or foreshadowing an event.\n2. Players act silently on-stage during the ballad.\n3. Players start to vocalize as the ballad ends.\n4. The ballad is used to change scenes, rescue a struggling scene, or bring closure to a scene that has reached a conclusion.\n5. No blackouts — all changes are made by the balladeer.\n6. A new musical genre (rap, rock, opera) can be used for each new ballad.\n7. If the balladeer gets into trouble, the players step in with a scene.",
+        "variations": [
+          {
+            "name": "Doo Wop",
+            "description": "The balladeer is replaced by a group song in the style of Doo Wop or any group make-a-song format (Hoe Down, March Song, Madrigal, Chant)."
+          }
+        ],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "translation-healthcare",
+      "name": "Translation-Healthcare",
+      "category": "handle-overlay",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "Translation-Healthcare is a handle overlaid on an open scene where a translator facilitates a healthcare interaction between a provider and a patient who speaks a made-up gibberish language. Unlike typical translation scenes, the translation is performed for another character on stage — not the audience — so the audience observes both sides. The format emphasizes character work, narrative arc, and avoiding cultural stereotypes.",
+        "howToPlay": "1. A host sets up a non-existent gibberish language (robot, economist, whale, toaster, etc.) and the healthcare scenario.\n2. One performer plays the patient speaking gibberish. Another plays the healthcare provider. A third translates between them.\n3. The patient communicates in gibberish with full physicality, emotion, and want; the translator interprets for the provider, and vice versa.\n4. Performers maintain a narrative arc exploring the healthcare interaction — not just the translation gimmick.",
+        "variations": [
+          {
+            "name": "Translated Opera",
+            "description": "As described, with the gibberish sung."
+          },
+          {
+            "name": "Translated Film",
+            "description": "As described, using movie thematics."
+          },
+          {
+            "name": "Bad Translator",
+            "description": "Real language translated by a non-speaker of that language."
+          },
+          {
+            "name": "Mechanical Translator",
+            "description": "Real language translated using Google Translate or similar."
+          },
+          {
+            "name": "Future In Laws",
+            "description": "Meet the parents/in-laws through a translator."
+          }
+        ],
+        "tips": [
+          "Set up a non-existent language (robot, economist, whale) rather than using gibberish for real languages, which can lead to stereotyping.",
+          "Create complete characters with movement and wants — don't let the translation gimmick replace the narrative arc.",
+          "Short translation for long gibberish (or vice versa) is a classic comedy gimmick."
+        ],
+        "referencedElements": [
+          "Gibberish"
+        ]
+      },
+      "actual": {
+        "description": "A handle where a translator facilitates a healthcare interaction with a patient who speaks a non-existent gibberish language. The translation is performed for another performer while the audience observes, requiring complete characters with movement and wants beyond the gibberish.",
+        "howToPlay": "1. The host sets up a non-existent language (e.g., robot, economist, whale, toaster) — avoid gibberish for existing languages to prevent stereotyping.\n2. One performer plays the patient speaking gibberish.\n3. Another performer plays the translator facilitating the healthcare interaction.\n4. All performers create complete characters with movement and wants in addition to the gibberish.\n5. Maintain a narrative arc that explores the healthcare interaction.\n6. Use gimmicks such as short translation for long gibberish, problems with idioms, differences in emotional content, or dirty words.",
+        "variations": [
+          {
+            "name": "Translated Opera",
+            "description": "Singing gibberish in an operatic style."
+          },
+          {
+            "name": "Translated Film",
+            "description": "Translation handle with movie thematics."
+          },
+          {
+            "name": "Bad Translator",
+            "description": "A real language translated by a non-speaker."
+          },
+          {
+            "name": "Mechanical Translator",
+            "description": "Using Google Translate as the translator."
+          },
+          {
+            "name": "Future In Laws",
+            "description": "Meet-the-parents or meet-the-in-laws scenario with translation."
+          }
+        ],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0,
+        "refRecall": 0
+      }
+    },
+    {
+      "elementId": "what-did-you-want",
+      "name": "What did you want to be when you grew up?",
+      "category": "ask-for-edge",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "\"What did you want to be when you grew up?\" is an audience ask-for prompt from learnimprov.com. It is a question used to solicit suggestions from the audience to inspire an improv scene, not a game or exercise in itself.",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "An audience ask-for prompt used to gather suggestions at the start of a scene or show.",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "deconstruction",
+      "name": "Deconstruction",
+      "category": "long-form-theory",
+      "source": "ircwiki",
+      "lang": "en",
+      "expected": {
+        "description": "The Deconstruction is a long-form improv structure developed by Del Close and The Family. It starts with a long two-person opening scene that introduces characters and a central problem, then \"deconstructs\" that scene through thematic scenes, commentary scenes, and an accelerating run of ever-shorter callbacks, before returning to the opening scene for a final resolution.",
+        "howToPlay": "1. Opening Scene (6–8 min): A long two-person scene establishing relationship and a problem — present but not solve it.\n2. Two Thematic Scenes (2–3 min each): Scenes exploring what the opening scene was ABOUT, taking one character's wants/flaws into new contexts.\n3. Return to Opening Scene (1.5–2 min): Clarify and solidify the central theme.\n4. Five Commentary Scenes (1.5–2 min each): Game-heavy scenes that comment on what was unusual or flawed about the opening characters.\n5. Second Return to Opening (1–1.5 min): Heighten the stakes using ideas from the commentary scenes.\n6. The Run: An intense, accelerating series of ever-shorter scenes pulling tangents from earlier material at breakneck pace.\n7. Opening Scene Returns/Final (1.5–2 min): Wrap up the show, often by going back in time to before the conflict began.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "A long form structure developed by Del Close featuring an opening scene, thematic scenes exploring what the scene was about, commentary scenes on character flaws, and a rapid concluding 'Run' leading to a final return to the opening scene.",
+        "howToPlay": "1. Play a long (6-8 minute) two-person opening scene focused on relationship and presenting an unresolved problem.\n2. Follow with two thematic scenes (2-3 minutes each), each exploring what the opening scene was about by examining one character's wants or flaws.\n3. Return to the opening scene (1.5-2 minutes) to clarify and solidify what the rest of the piece is about.\n4. Play five commentary scenes (1.5-2 minutes each) commenting on what was unusual or flawed about the opening characters. Focus on 'bits' — straight man vs. absurd man.\n5. Return to the opening scene again (1-1.5 minutes) to heighten the stakes using ideas from the commentary scenes.\n6. Play 'The Run' — an intense series of ever-shorter scenes where pace is as important as content. Anything goes; consistently pick up the pace until reaching a breakneck speed.\n7. Return to the opening scene for the finale (1.5-2 minutes). A classic technique is to go back in time, showing the characters before their conflict began.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "game-concept",
+      "name": "Game",
+      "category": "concept-no-howtoplay",
+      "source": "ircwiki",
+      "lang": "en",
+      "expected": {
+        "description": "\"Game\" is a foundational improv concept with distinct meanings in shortform and longform. In shortform, a game is a set of pre-determined rules governing a scene's structure. In longform, the \"game of the scene\" is the interesting or funny pattern discovered during improvisation. Finding the game involves identifying the situation, spotting the first unusual thing, and asking \"if this is true, then what else is true?\" to heighten the pattern.",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [
+          "In shortform, a game is a set of pre-determined rules that govern the general structure of any scene.",
+          "In longform, find the game by answering three questions: What is the situation? What is the first unusual thing? If this is true, then what else is true?",
+          "The situation (who, where, what) can be established very quickly — within a few lines, or even through environment and object work before anyone speaks."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Game is an improvisational concept used differently in shortform (pre-determined rules governing scene structure) and longform (what makes a scene interesting or funny). Finding the game involves identifying the situation, the first unusual thing, and asking 'if this is true, what else is true?' to explore and heighten a pattern of behavior.",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0,
+        "refRecall": 1
+      }
+    }
+  ]
+}

--- a/src/normalize/__testdata__/results/pro-results.json
+++ b/src/normalize/__testdata__/results/pro-results.json
@@ -1,0 +1,749 @@
+{
+  "meta": {
+    "model": "deepseek-v4-pro",
+    "modelId": "opencode-go/deepseek-v4-pro",
+    "opencodeVersion": "1.15.5",
+    "timestamp": "2026-06-03T16:52:27.640Z",
+    "runId": "2026-06-03T16-52-27-640Z",
+    "elementCount": 15,
+    "promptChars": 21166,
+    "outputChars": 23901,
+    "elapsedSeconds": 192.1
+  },
+  "results": [
+    {
+      "elementId": "freeze-tag",
+      "name": "Freeze Tag",
+      "category": "well-structured-game",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Freeze Tag is a fast-paced improv game where two players start a scene, anyone calls \"Freeze!\" to lock them in position, and a new player taps in, assumes the frozen pose, and launches an entirely new, unrelated scene. It trains spontaneity, physicality, and the core improv principle of accepting what you are given and building on it. Also known as \"Freeze\", \"Zap\", \"Chain Impro\" or \"Tap Out\".",
+        "howToPlay": "1. Two players begin a scene with full physical commitment — moving, using the space, no \"talking heads\".\n2. Any waiting player shouts \"Freeze!\" or \"Stop!\" when the stage picture is strong or interesting.\n3. Both stage players freeze instantly in their exact poses — no drift, no relaxation.\n4. A waiting player steps forward, gently taps out one frozen player, and takes over that exact pose. The tapped-out player leaves the stage.\n5. The new player immediately begins a completely new scene, justifying the pose with fresh characters, setting, and story — totally unrelated to the previous scene.\n6. Repeat until the group decides to end.",
+        "variations": [
+          {
+            "name": "Blind Freeze",
+            "description": "Waiting players stand with their backs to the stage. They call \"stop\", turn around, and must work with whatever picture they find. Prevents pre-planning and pushes pure spontaneity."
+          },
+          {
+            "name": "Elimination Freeze",
+            "description": "Competitive version. Players who hesitate, lack ideas, or stall in justification are eliminated. The last remaining player is the \"freeze king\". Works especially well in shows."
+          },
+          {
+            "name": "Object Freeze",
+            "description": "Poses must involve interaction with an invisible object. Every new scene defines what object is being held or manipulated by the body posture."
+          }
+        ],
+        "tips": [
+          "Avoid the obvious continuation — a raised arm doesn't always have to be a traffic cop. Take the idea one step further.",
+          "Give extreme and dynamic poses as gifts when you are on stage. Static standing offers no inspiration to the next player.",
+          "Time the freeze when the stage picture is especially strong or a conflict has just peaked — not too early, not too late.",
+          "Watch colleagues' poses carefully from the sideline. Inaccurate pose reproduction leads to a wooden new scene start."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Freeze Tag is a fast-paced improv game where players steal a frozen body posture and breathe new life into it in a completely different scene. It's a classic warm-up and performance game that trains spontaneity and the 'yes, and' principle.",
+        "howToPlay": "1. All players form a loose half-circle at the edge of the stage. Two players step out and begin a scene with full physical commitment.\n2. The two players move, use the space and react to each other. No 'talking heads'.\n3. Any waiting player can shout 'Freeze!' or 'Stop!' when the picture on stage is strong or interesting.\n4. Both stage players freeze instantly in their exact poses. No drift, no relaxation.\n5. A waiting player walks on, gently taps out one of the frozen players and takes over that exact pose.\n6. The new player justifies the pose with a completely fresh scene. Story, setting and characters have nothing to do with what came before.",
+        "variations": [
+          {
+            "name": "Blind Freeze",
+            "description": "Waiting players stand with their back to the stage. Whoever feels the time is right calls 'stop', turns around and has to work with whatever picture they find, pushing pure spontaneity."
+          },
+          {
+            "name": "Elimination Freeze",
+            "description": "Competitive version where anyone who lacks a quick idea, hesitates too long or stalls is out. At the end one 'freeze king' remains."
+          },
+          {
+            "name": "Object Freeze",
+            "description": "Focus is on poses involving interaction with an invisible object. Every new scene must define an object held or moved by the body posture."
+          }
+        ],
+        "tips": [
+          "Avoid the obvious continuation. If someone is frozen with a raised arm, the policeman directing traffic is the first idea everyone has. Try to take a step further.",
+          "Give extreme poses as gifts. Putting yourself in uncomfortable or dynamic positions is a wonderful gift to your colleagues.",
+          "A good freeze hits when the picture is especially strong or when a conflict has just reached its peak.",
+          "Watch carefully. Whoever stands at the side of the stage shouldn't only be thinking about their own next idea."
+        ],
+        "referencedElements": [
+          "Zap",
+          "Chain Impro",
+          "Tap Out",
+          "Blind Freeze",
+          "Elimination Freeze",
+          "Object Freeze"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.75,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "half-life",
+      "name": "Half-Life",
+      "category": "inline-variant",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Half-Life (also known as Fast Forward) is an improv game where a scene is first played in one minute, then repeated in ever-shorter time frames — 30, 15, 7, 3, and finally 1 second. The rapid compression forces players to strip each repetition down to the essential beats, and the resulting slapstick effect reliably generates laughs even from weak starting material.",
+        "howToPlay": "1. Ask the audience for a dramatic situation to start the scene.\n2. Play a scene with as much action as possible — location changes, dialogue, drama.\n3. After one minute, repeat the same scene in 30 seconds, hitting all the key anchor points.\n4. Repeat again in 15 seconds, then 7, then 3, then 1 second, each time compressing to the essentials.",
+        "variations": [
+          {
+            "name": "Variable Start Length",
+            "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+          }
+        ],
+        "tips": [
+          "Ask the audience for a suggestion based on a dramatic situation — it gives the scene stakes from the start.",
+          "The starting scene should contain as much action as possible: changes of location, dialogue, drama — the more material, the funnier the compressions.",
+          "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Half-Life (also known as Fast Forward) is an improv game where a scene is played within one minute and then repeated in progressively shorter time frames of 30, 15, 7, 3, and finally 1 second. The shortening forces players to reduce the scene to its essentials, creating a guaranteed laugh through slapstick compression.",
+        "howToPlay": "1. Ask the audience for a suggestion based on a dramatic situation.\n2. Play a starting scene within one minute, filled with as much action as possible: changes of location, dialogue, and drama.\n3. Repeat the scene in 30 seconds, keeping the key anchor points of the original scene.\n4. Repeat the scene in 15 seconds, further compressing to essentials.\n5. Repeat the scene in 7 seconds.\n6. Repeat the scene in 3 seconds.\n7. Repeat the scene in 1 second.",
+        "variations": [
+          {
+            "name": "Flexible Start",
+            "description": "The starting scene can have any length, and the first compression then cuts it down to one minute."
+          }
+        ],
+        "tips": [
+          "It helps to ask the audience for a suggestion based on a dramatic situation.",
+          "The starting scene should contain as much action as possible: changes of location, dialogue, drama and so on.",
+          "Always keep the key anchor points of the original scene in the shorter follow-up rounds. The game lives from the repetition of exactly these defining beats.",
+          "The audience enjoys watching the players struggle, race against the clock and end up completely out of breath."
+        ],
+        "referencedElements": [
+          "Fast Forward"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 0,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "yes-no",
+      "name": "Yes - No",
+      "category": "minimal-content",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Yes - No is a simple paired improv exercise where one player can only say \"Yes\" and the other only \"No\". Despite having just one word each, they carry out a full conversation using tone, volume, rhythm, pauses, and body language. Roles are swapped partway through.",
+        "howToPlay": "1. Form pairs. One player may only say \"Yes\", the other only \"No\".\n2. Have a full conversation despite the limitation, using tone, volume, rhythm, pauses, and body language to convey meaning.\n3. After a while, switch roles so each player experiences both constraints.",
+        "variations": [],
+        "tips": [
+          "Communication is mostly non-verbal — this exercise makes that vivid by restricting vocabulary to a single word each.",
+          "Use tone, volume, rhythm, and pauses to differentiate between question, statement, anger, excitement, and other meanings."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "An improv exercise where players form pairs. One can only say 'Yes', the other only 'No'. Despite this verbal limitation, they have a full conversation using tone, volume, rhythm, pauses, and body language. After a while, roles switch.",
+        "howToPlay": "1. Form pairs.\n2. One player can only say 'Yes', the other only 'No'.\n3. Have a full conversation using only these words, relying on tone, volume, rhythm, pauses, and body language to communicate meaning.\n4. After a while, switch roles so the 'Yes' player becomes 'No' and vice versa.",
+        "variations": [],
+        "tips": [
+          "Use tone, volume, rhythm, pauses, and body language to convey meaning beyond the single word.",
+          "This exercise trains vocal expression and status play.",
+          "Communication is mostly non-verbal — embrace that realization."
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.5,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "mirror-exercises",
+      "name": "Mirror Exercises",
+      "category": "short-exercise",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Mirror Exercises is a classic paired improv warm-up where two players face each other and one mirrors the other's slow movements exactly. The goal is for an outside observer to be unable to tell who is leading and who is following. It trains observation, patience, and physical synchronization.",
+        "howToPlay": "1. Two players face each other. One leads with slow, deliberate movements while the other mirrors exactly.\n2. The goal is for an observer to not be able to tell who leads.\n3. Switch roles after a while.\n4. Eventually, try leading and following simultaneously with no designated leader.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "A classic improv exercise where two players face each other. One leads with slow movements while the other mirrors exactly, with the goal that an observer cannot tell who is leading. Over time, players switch roles and eventually try leading and following simultaneously with no designated leader.",
+        "howToPlay": "1. Two players face each other.\n2. One player leads with slow, deliberate movements while the other mirrors exactly, as if looking in a mirror.\n3. The goal is for an observer to not be able to tell who is leading.\n4. After a while, switch roles so the other player leads.\n5. Eventually, try leading and following simultaneously with no designated leader.",
+        "variations": [],
+        "tips": [
+          "Move slowly and deliberately so the partner can follow precisely.",
+          "The goal is for an observer to not be able to tell who is leading.",
+          "This exercise trains observation, patience, and physical synchronization."
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "talk-at-touch",
+      "name": "Talk at touch",
+      "category": "medium-game",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Talk at touch is a two-player improv game where speaking is only allowed while one player is physically touching the other, and only the player who initiated the touch may talk. Permanent contact like holding hands is prohibited. The constant alternation between mute physical play and spoken sections creates comedy from the necessity to touch in order to communicate.",
+        "howToPlay": "1. Two players perform a scene, optionally with an audience suggestion.\n2. A player may only speak while touching the other player, and only the touching player may talk.\n3. Permanent contact such as holding hands is prohibited — touch must be initiated anew each time.\n4. This produces a rhythm of mute physical sections alternating with spoken dialogue.",
+        "variations": [
+          {
+            "name": "Bidirectional Touch",
+            "description": "A touch is valid in both directions: as soon as contact exists, both players may speak regardless of who initiated it. When contact breaks, both must be silent and can only play pantomime."
+          }
+        ],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "An improv game where two players perform a scene but are only allowed to speak while physically touching each other. Only the person who initiates the touch may speak. Permanent contact such as holding hands is prohibited. This creates a rhythm alternating between mute pantomime and spoken sections.",
+        "howToPlay": "1. Two players perform a scene, optionally with input from the audience.\n2. Players may only speak while one player is touching the other.\n3. Only the person who initiates the touch is allowed to speak.\n4. Permanent contact such as holding hands is prohibited.\n5. Players alternate between mute pantomime sections and spoken sections, creating comedy from the necessity to touch in order to communicate.",
+        "variations": [
+          {
+            "name": "Bidirectional Touch",
+            "description": "A touch is valid in both directions — as soon as contact is made, both may speak regardless of who initiated the touch. As soon as contact breaks, both must be silent and can only play pantomime."
+          }
+        ],
+        "tips": [
+          "The comedy arises from the necessity of players to touch each other in order to communicate.",
+          "Use the mute sections for physical storytelling and pantomime.",
+          "Avoid permanent contact like holding hands — the alternating rhythm of touch and release is key."
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "swinging-pendulum",
+      "name": "Swinging Pendulum of Death",
+      "category": "external-refs",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Swinging Pendulum of Death is a complex three-player improv game with strong narrative structure. Each player is given a distinct character, location, and conflict. The game cycles through three locations, with one character dying at each, then repeatedly revisits locations at random — requiring the actor who died there to drop dead instantly while the others deal with the aftermath.",
+        "howToPlay": "1. Assign each of three actors a location, a conflict, and a character.\n2. Start at the first actor's location. The other two adapt to fit that scenario. Play the scene until that actor's character dies.\n3. The judge calls a new location. The actor who just died returns as a new character. Play the scene until the second actor's character dies.\n4. Repeat for the third location until the third character dies.\n5. Once all three deaths are established, the judge calls locations at random. The actor who died in that location immediately drops dead, and the others continue the aftermath. Repeat until the game ends.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "The Swinging Pendulum of Death is a complex and entertaining improv game for 3 actors. Each actor is given a location, conflict, and character. Scenes are played at each location where one character dies, then the game cycles through locations at random as the dead character immediately drops dead and the others deal with the aftermath.",
+        "howToPlay": "1. Each of the 3 actors is given a location, a conflict, and a character, based on audience suggestions.\n2. The game starts at the first location. The actor whose character belongs to that location is established, and the other two actors play supporting characters. The scene must be built up to the point that the main character dies.\n3. A judge calls out one of the other two locations. The dead actor 'comes back to life' as a new character within the new location, and the scene is advanced until another character dies.\n4. Repeat for the third location, where the previously dead character comes to life again and the scene is played until the third character dies.\n5. After all three deaths are established, the judge calls any location at random. The actor who died in that location must immediately drop dead, and the others pick up where the scene left off, dealing with the aftermath of the death.\n6. Continue calling locations at random until the end of the game.",
+        "variations": [],
+        "tips": [
+          "This game is complicated but can be extremely entertaining if done well.",
+          "Each scene must be advanced to the point that the designated character dies.",
+          "When a location is called after all deaths, the actor who died there must drop dead immediately and the others must react to the aftermath."
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "superscene",
+      "name": "Superscene",
+      "category": "long-form-show",
+      "source": "improwiki",
+      "lang": "en",
+      "expected": {
+        "description": "Superscene is a long-form improv show format for three to five players, structured as a competitive storytelling tournament. Each player acts as a director for their own story, casting the others as actors. After all directors have presented one scene, the audience votes by applause to eliminate one story each round until a single \"Superscene\" remains.",
+        "howToPlay": "1. Three to five players participate. Each takes a turn as \"director\" of their own story.\n2. The director introduces the scene, asks the audience for guidelines, and may impose additional requirements (rhyme, genre, ABC-game, etc.).\n3. The other players perform the scene. The director ends it at a chosen moment.\n4. After all directors have presented, each briefly promotes their story to the audience.\n5. The audience votes by applause on each scene. The scene with the least applause is eliminated.\n6. The remaining directors receive additional audience guidelines for the next round. Play another round without the eliminated story.\n7. Repeat until one story remains — the \"Superscene\".",
+        "variations": [],
+        "tips": [
+          "Directors should only promote their own story — never comment on or disparage others.",
+          "End each scene with a cliff-hanger to make the audience curious and invested in seeing the sequel.",
+          "The goal is to arouse and maintain the audience's interest in the progress of the story across rounds.",
+          "Despite the competitive format, this is about creative cooperation — all players should give their best in every scene, regardless of whose story it is."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Superscene is an improv game for three to five players where each takes a turn as director of their own story scene. After all scenes are performed, the audience votes by applause, eliminating one story each round until a single 'Superscene' remains as the audience's favorite.",
+        "howToPlay": "1. Three to five players participate. Each is responsible for one story as its director.\n2. The first director introduces their scene and asks the audience for guidelines (e.g., location, genre, or other constraints).\n3. The other players perform the scene. At a given time, the director ends the scene.\n4. The next player becomes director, introduces their scene with new guidelines, and it is performed. This continues until all players have directed once.\n5. All directors briefly promote their story and explain why the audience should see its sequel.\n6. The audience votes by applause on each scene. The scene with the least applause is eliminated.\n7. For the second round, each remaining director receives additional guidelines from the audience and optional suggestions from other players. Scenes are performed and voted on again, with one eliminated.\n8. Repeat until one story remains — the 'Superscene'.",
+        "variations": [],
+        "tips": [
+          "Directors only promote their own story — they should not comment on or disparage others.",
+          "It is sensible to end each scene with a cliff-hanger.",
+          "The director does not cut off the continuing scene by the rules any more.",
+          "Even though directors are supposedly competitors, all should still try to give their best in every scene."
+        ],
+        "referencedElements": [
+          "ABC-game"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.25,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "gefuehlspunkte",
+      "name": "Gefühlspunkte",
+      "category": "german-content",
+      "source": "improwiki",
+      "lang": "de",
+      "expected": {
+        "description": "Bei Gefühlspunkte werden zwei gut sichtbare Punkte auf die Bühne geklebt und jedem wird per Publikumszuruf ein gegensätzliches Gefühl zugeordnet (z.B. Hass und Liebe). Die Spieler improvisieren eine zusammenhängende Szene an einem vom Publikum vorgegebenen Ort, wobei sie ihre Figur je nach Nähe zu einem Gefühlspunkt in der entsprechenden Emotion einfärben — direkt auf dem Punkt erfolgt der völlige Gefühlsausbruch.",
+        "howToPlay": "1. Zwei gut sichtbare Punkte werden auf der Bühne markiert.\n2. Das Publikum ordnet jedem Punkt ein gegensätzliches Gefühl zu (z.B. Hass und Liebe, Eifersucht und Gleichgültigkeit).\n3. Das Publikum gibt einen Ort für die Szene vor.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je näher ein Spieler einem Gefühlspunkt kommt, desto stärker spielt er die entsprechende Emotion aus. Auf dem Punkt selbst erfolgt der völlige Gefühlsausbruch.",
+        "variations": [],
+        "tips": [
+          "Nicht nur die Extreme auf den Gefühlspunkten spielen, sondern auch die Abstufungen und Übergänge der Gefühle zwischen den Punkten.",
+          "Zusätzlich zum Ort kann das Publikum auch Gegenstände oder Raumdetails an den Gefühlspunkten vorgeben (z.B. ein Sessel am Hass-Punkt, ein Fernseher am Liebes-Punkt).",
+          "Größere Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich wirken."
+        ],
+        "referencedElements": [
+          "Gefühlsquadrat"
+        ]
+      },
+      "actual": {
+        "description": "Zwei gut sichtbare Punkte werden auf die Bühne geklebt. Jedem Punkt wird durch Publikumszuruf ein Gefühl zugeordnet. Die Spieler entwickeln eine zusammenhängende Geschichte, wobei sich die Charaktere frei auf der Bühne bewegen können und je nach Standort zum Gefühlspunkt ihre Figur in der entsprechenden Emotion einfärben. Die Emotion wird stärker, je näher der Spieler dem Punkt kommt.",
+        "howToPlay": "1. Zwei gut sichtbare Punkte auf die Bühne kleben.\n2. Jedem Punkt wird durch Publikumszuruf ein Gefühl zugeordnet, am besten gegensätzliche (z.B. Hass–Liebe, Eifersucht–Gleichgültigkeit, Trauer–Freude).\n3. Das Publikum gibt einen Ort vor, an dem die Szene entstehen soll.\n4. Die Spieler entwickeln eine zusammenhängende Geschichte und bewegen sich frei auf der Bühne.\n5. Je nach Standort des Spielers (Nähe zu einem Gefühlspunkt) wird die Figur unterschiedlich in der entsprechenden Emotion gespielt.\n6. Die Emotion wird immer stärker, je näher der Spieler dem Gefühlspunkt kommt. Auf dem Gefühlspunkt gibt es den völligen Gefühlsausbruch.",
+        "variations": [],
+        "tips": [
+          "Es ist wichtig, nicht nur die Extreme auf den Gefühlspunkten zu spielen, sondern auch die Abstufungen der Gefühle zwischen diesen.",
+          "Zusätzlich zum Ort kann man sich auch noch Gegenstände oder Raum- oder Ortsdetails geben lassen, die an dem betreffenden Gefühlspunkt vorhanden sind.",
+          "Die größeren Bewegungen zwischen den Gefühlspunkten sollten begründet erfolgen und nicht willkürlich erscheinen."
+        ],
+        "referencedElements": [
+          "Gefühlsquadrat"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.6666666666666666,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "distanz-schlaegerei",
+      "name": "Distanz-Schlägerei",
+      "category": "german-exercise",
+      "source": "improwiki",
+      "lang": "de",
+      "expected": {
+        "description": "Distanz-Schlägerei ist eine pantomimische Aufwärmübung, bei der zwei Spieler in sicherer Entfernung einen Kampf simulieren. Der Angreifer attackiert mit wechselnden Körperteilen aus der Distanz, der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden. Die Übung kann paarweise oder in der ganzen Gruppe gespielt werden.",
+        "howToPlay": "1. Zwei Spieler stellen sich in angemessener Entfernung gegenüber auf.\n2. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer nutzt wechselnd Füße, Arme, Kopf und Schultern, um plötzlich und immer wieder zu attackieren — stets aus sicherer Entfernung.\n3. Der Verteidiger reagiert spontan, als wäre er wirklich getroffen worden.\n4. Variante: Die ganze Gruppe kämpft gleichzeitig, \"jeder gegen jeden\".",
+        "variations": [],
+        "tips": [
+          "Die Übung eignet sich gut zum Aufwärmen, zum Hemmungen- und Frust-Abbauen und trainiert den körperlichen Ausdruck.",
+          "Trotz der Distanz muss der Verteidiger überzeugend und spontan auf jeden Angriff reagieren."
+        ],
+        "referencedElements": [
+          "Zeitlupenschlägerei"
+        ]
+      },
+      "actual": {
+        "description": "Zwei Spieler stehen sich in angemessener Entfernung gegenüber. Einer ist der Angreifer, der andere der Verteidiger. Der Angreifer attackiert plötzlich mit Füßen, Armen, Kopf oder Schulter, jedoch immer in sicherer Entfernung. Der Angegriffene reagiert spontan, als ob er wirklich getroffen worden wäre. Die Übung dient zum Aufwärmen, Hemmungen- und Frust-Abbauen und trainiert den Ausdruck.",
+        "howToPlay": "1. Zwei Spieler stellen sich in angemessener Entfernung gegenüber.\n2. Einer ist der Angreifer, der andere der Verteidiger.\n3. Der Angreifer nutzt wechselnd Füße, Arme, Kopf, Schulter, um plötzlich und immer wieder den Verteidiger zu attackieren — jedoch immer in sicherer Entfernung.\n4. Der Angegriffene reagiert spontan so, als wenn er wirklich getroffen worden wäre.\n5. Optional kann das Spiel paarweise oder mit der ganzen Gruppe 'jeder gegen jeden' gespielt werden.",
+        "variations": [],
+        "tips": [
+          "Die Übung ist zum Aufwärmen geeignet und gut zum Hemmungen- und Frust-Abbauen.",
+          "Die Distanz muss immer sicher bleiben — kein tatsächlicher Körperkontakt.",
+          "Die Reaktionen des Verteidigers sollten spontan und realistisch wirken."
+        ],
+        "referencedElements": [
+          "Zeitlupenschlägerei"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.5,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "harold-french",
+      "name": "Harold-French",
+      "category": "learnimprov-structured",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "Harold-French (also called Herald or Sheila) is a version of the Harold long-form improv format where all scenes take place in a single environment. The Harold itself is a classic structure of three sets of three scenes connected by a common theme, created by Del Close. Scene transitions are controlled by offstage ensemble members through various \"wipe\" techniques.",
+        "howToPlay": "1. Get a broad general theme from the audience (single word or phrase).\n2. The ensemble opens with a group riff on the theme — free associations, a group song, or similar.\n3. Play 3 open scenes informed by but not directly related to each other.\n4. Perform a predetermined group handle (another structured bit).\n5. Repeat this cycle 3 times total, for 9 open scenes. By the last round, stories should begin to weave together.\n6. Scene transitions are controlled by offstage members through wipes: clap, front wipe, tap out, lights dim, or coach call.",
+        "variations": [
+          {
+            "name": "Monoscene",
+            "description": "A Harold that takes place in one environment."
+          },
+          {
+            "name": "Blind Harold",
+            "description": "Participants are seated and blindfolded in the dark."
+          },
+          {
+            "name": "The Bat",
+            "description": "Unblindfolded Harold performed in the dark."
+          },
+          {
+            "name": "Armando",
+            "description": "Scenes are interceded by true story monologues from a designated monologist."
+          },
+          {
+            "name": "Triple Play",
+            "description": "3 by 3 scenes with no interceding handles."
+          }
+        ],
+        "tips": [
+          "The theme should be as broad as possible. Nouns are discouraged. For example, \"toothbrush\" could be wrangled into the theme \"cleaning\".",
+          "A smart group will put their best storyteller as their balladeer, not the best singer."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "French Harold (also called Herald or Sheila) is a long-form improv structure that takes place in one environment. It consists of a series of scenes loosely associated to one common theme, typically following a format of 3 sets of 3 scenes interceded by group handles. The format was created by Del Close.",
+        "howToPlay": "1. Ask the audience for a general theme.\n2. Any number of improvisers riff off the theme as a group (free associations, group song, etc.) as an opening handle.\n3. Perform 3 open scenes, not related to each other but informed by the theme.\n4. Play another group handle.\n5. Repeat the cycle of 3 scenes followed by a handle two more times, for a total of 9 open scenes.\n6. By the last round, stories should start to weave together.\n7. Scene transitions are determined by offstage ensemble members using wipes (clap, front wipe, tap out, ass wipe, technical, director cut).",
+        "variations": [
+          {
+            "name": "Monoscene",
+            "description": "A Harold that takes place in one environment."
+          },
+          {
+            "name": "Blind Harold",
+            "description": "A Harold performed blindfolded in the dark."
+          },
+          {
+            "name": "The Bat",
+            "description": "An unblindfolded Harold performed in the dark."
+          },
+          {
+            "name": "Armando",
+            "description": "A Harold where scenes are interceded by true story monologues."
+          },
+          {
+            "name": "Sybil",
+            "description": "A Harold performed by a single performer."
+          },
+          {
+            "name": "The Narce",
+            "description": "A single performer Harold."
+          },
+          {
+            "name": "Triple Play",
+            "description": "3 by 3 scenes with no interceding handles."
+          }
+        ],
+        "tips": [
+          "The audience does not participate further with suggestions after the initial theme.",
+          "All 11 to 12 scenes should be based on the chosen theme.",
+          "Transitions are determined by offstage ensemble members, not called from a booth.",
+          "By the last round of scenes, stories should start to weave together."
+        ],
+        "referencedElements": [
+          "Monoscene",
+          "Blind Harold",
+          "The Bat",
+          "Armando",
+          "Sybil",
+          "The Narce",
+          "Triple Play",
+          "Del Close",
+          "Herald",
+          "Sheila"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "balladeer-doo-wop",
+      "name": "Balladeer-Doo Wop",
+      "category": "musical-form",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "Balladeer-Doo Wop (also known as Minstrel or Musical MC) is a long-form musical improv structure directed by a singing balladeer. The accompanist and singer introduce characters, locations, or events through short songs while actors perform silently on stage. The ballads control scene changes, rescues, and closures — there are no blackouts.",
+        "howToPlay": "1. An accompanist and singer (the balladeer) start with a short song (30–60 seconds) introducing a character, location, or foreshadowing an event.\n2. While the balladeer sings, players act on stage silently. When the ballad ends, they begin speaking.\n3. The balladeer uses subsequent ballads to change scenes, rescue struggling scenes, or bring scenes to a conclusion.\n4. No blackouts — all scene transitions are controlled by the balladeer.\n5. Each ballad can use a different musical genre: rap, rock, opera, etc.",
+        "variations": [
+          {
+            "name": "Doo Wop",
+            "description": "The balladeer is replaced by a group song in the style of Doo Wop. The group song can be any form of group make-a-song — Hoe Down, March Song, Madrigal, or Chant."
+          }
+        ],
+        "tips": [
+          "Put your best storyteller as the balladeer, not necessarily the best singer.",
+          "If the balladeer gets into trouble, the players must step in with a scene to recover.",
+          "Musical bits should be short — thirty seconds to a minute is usually enough to pass on story information."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Balladeer (also known as Minstrel, Musical MC, or Doo Wop) is an improv format where a singer and accompanist direct scenes through short improvised songs. The balladeer introduces characters, locations, or events through song while actors perform silently on stage, then begin vocalizing as the ballad ends. The ballad is used to change scenes, rescue struggling scenes, or bring closure.",
+        "howToPlay": "1. The accompanist and the singer start with a short song (30 seconds to 1 minute) that may introduce a character, location, or foreshadow an event.\n2. Simultaneously, players act on-stage silently while the balladeer sings.\n3. As the ballad ends, the on-stage players start to vocalize and perform the scene.\n4. The balladeer uses subsequent ballads to change scenes, rescue a struggling scene, or bring closure to a scene that has reached a conclusion.\n5. No blackouts are used — all changes are made by the balladeer.\n6. If the balladeer gets into trouble, the players need to step in with a scene.",
+        "variations": [
+          {
+            "name": "Doo Wop",
+            "description": "The balladeer is replaced by a group song in the style of Doo Wop. The group song could be any manner of group make-a-song such as Hoe Down, March Song, Madrigal, or Chant."
+          }
+        ],
+        "tips": [
+          "A new musical genre can be used for each new ballad: rap, rock, opera.",
+          "The musical bits are meant to be short — thirty seconds to a minute.",
+          "A smart group puts their best storyteller as balladeer, not the best singer.",
+          "If the balladeer gets into trouble, the players need to step in with a scene."
+        ],
+        "referencedElements": [
+          "Minstrel",
+          "Musical MC",
+          "Doo Wop",
+          "Hoe Down",
+          "March Song",
+          "Madrigal",
+          "Chant"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "translation-healthcare",
+      "name": "Translation-Healthcare",
+      "category": "handle-overlay",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "Translation-Healthcare is a handle overlaid on an open scene where a translator facilitates a healthcare interaction between a provider and a patient who speaks a made-up gibberish language. Unlike typical translation scenes, the translation is performed for another character on stage — not the audience — so the audience observes both sides. The format emphasizes character work, narrative arc, and avoiding cultural stereotypes.",
+        "howToPlay": "1. A host sets up a non-existent gibberish language (robot, economist, whale, toaster, etc.) and the healthcare scenario.\n2. One performer plays the patient speaking gibberish. Another plays the healthcare provider. A third translates between them.\n3. The patient communicates in gibberish with full physicality, emotion, and want; the translator interprets for the provider, and vice versa.\n4. Performers maintain a narrative arc exploring the healthcare interaction — not just the translation gimmick.",
+        "variations": [
+          {
+            "name": "Translated Opera",
+            "description": "As described, with the gibberish sung."
+          },
+          {
+            "name": "Translated Film",
+            "description": "As described, using movie thematics."
+          },
+          {
+            "name": "Bad Translator",
+            "description": "Real language translated by a non-speaker of that language."
+          },
+          {
+            "name": "Mechanical Translator",
+            "description": "Real language translated using Google Translate or similar."
+          },
+          {
+            "name": "Future In Laws",
+            "description": "Meet the parents/in-laws through a translator."
+          }
+        ],
+        "tips": [
+          "Set up a non-existent language (robot, economist, whale) rather than using gibberish for real languages, which can lead to stereotyping.",
+          "Create complete characters with movement and wants — don't let the translation gimmick replace the narrative arc.",
+          "Short translation for long gibberish (or vice versa) is a classic comedy gimmick."
+        ],
+        "referencedElements": [
+          "Gibberish"
+        ]
+      },
+      "actual": {
+        "description": "Translation-Healthcare is an improv handle overlaid on an open scene where a translator facilitates a healthcare interaction. The patient (or healthcare worker) speaks a non-existent gibberish language while the translator interprets. Performers must create complete characters with movement and wants in addition to the gibberish, maintaining a narrative arc around the healthcare interaction.",
+        "howToPlay": "1. The host sets up a non-existent language for the patient or healthcare worker (e.g., robot, economist, whale, toaster) — avoid using gibberish for existing languages to prevent stereotyping.\n2. The translator facilitates communication between the healthcare worker and the patient, translating the gibberish for the other performer while the audience observes.\n3. The performers create complete characters with movement and wants in addition to the gibberish.\n4. Maintain a narrative arc that explores the healthcare interaction throughout the scene.",
+        "variations": [
+          {
+            "name": "Translated Opera",
+            "description": "Singing gibberish in an operatic style."
+          },
+          {
+            "name": "Translated Film",
+            "description": "Using movie thematics with the translation format."
+          },
+          {
+            "name": "Bad Translator",
+            "description": "A real language is translated by a non-speaker."
+          },
+          {
+            "name": "Mechanical Translator",
+            "description": "Using a Google Translate style mechanical translation."
+          },
+          {
+            "name": "Future In Laws",
+            "description": "Meet the parents or in-laws scenario with translation."
+          }
+        ],
+        "tips": [
+          "It is recommended to set up a non-existent language — using gibberish for existing languages can lead to stereotyping.",
+          "The performers must create complete characters with movement and wants in addition to the gibberish.",
+          "Gimmicks that work well: short translation for long gibberish (or vice versa), problems with idioms, differences in emotional content, dirty words."
+        ],
+        "referencedElements": [
+          "Translated Opera",
+          "Translated Film",
+          "Bad Translator",
+          "Mechanical Translator",
+          "Future In Laws"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.6666666666666666,
+        "refRecall": 0
+      }
+    },
+    {
+      "elementId": "what-did-you-want",
+      "name": "What did you want to be when you grew up?",
+      "category": "ask-for-edge",
+      "source": "learnimprov",
+      "lang": "en",
+      "expected": {
+        "description": "\"What did you want to be when you grew up?\" is an audience ask-for prompt from learnimprov.com. It is a question used to solicit suggestions from the audience to inspire an improv scene, not a game or exercise in itself.",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "An audience ask-for prompt: 'What did you want to be when you grew up?' This is not a game or exercise but a question posed to the audience to generate suggestions for improvisational scenes.",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "deconstruction",
+      "name": "Deconstruction",
+      "category": "long-form-theory",
+      "source": "ircwiki",
+      "lang": "en",
+      "expected": {
+        "description": "The Deconstruction is a long-form improv structure developed by Del Close and The Family. It starts with a long two-person opening scene that introduces characters and a central problem, then \"deconstructs\" that scene through thematic scenes, commentary scenes, and an accelerating run of ever-shorter callbacks, before returning to the opening scene for a final resolution.",
+        "howToPlay": "1. Opening Scene (6–8 min): A long two-person scene establishing relationship and a problem — present but not solve it.\n2. Two Thematic Scenes (2–3 min each): Scenes exploring what the opening scene was ABOUT, taking one character's wants/flaws into new contexts.\n3. Return to Opening Scene (1.5–2 min): Clarify and solidify the central theme.\n4. Five Commentary Scenes (1.5–2 min each): Game-heavy scenes that comment on what was unusual or flawed about the opening characters.\n5. Second Return to Opening (1–1.5 min): Heighten the stakes using ideas from the commentary scenes.\n6. The Run: An intense, accelerating series of ever-shorter scenes pulling tangents from earlier material at breakneck pace.\n7. Opening Scene Returns/Final (1.5–2 min): Wrap up the show, often by going back in time to before the conflict began.",
+        "variations": [],
+        "tips": [],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "The Deconstruction is a long-form improv structure developed by Del Close and The Family. It begins with a long two-person opening scene that provides information for the rest of the piece, followed by thematic scenes exploring wants and flaws, returns to the opening scene, commentary scenes, and an intense series of ever-shorter scenes called 'The Run' before a final return to wrap up the show.",
+        "howToPlay": "1. Perform a long (6-8 minute) two-person opening scene focused on relationship and exploring a problem that is presented but not solved.\n2. Perform two thematic scenes (2-3 minutes each), each exploring what the opening scene was about by taking one character's actions and exploring their wants and flaws.\n3. Return to the opening scene (1.5-2 minutes) to clarify and solidify what the rest of the piece is about.\n4. Perform five commentary scenes (1.5-2 minutes each) that comment on what was unusual or flawed about the characters in the opening scene. These should be game-heavy, focusing on straight man vs. absurd man.\n5. Return to the opening scene again (1-1.5 minutes) to heighten the stakes using ideas from the commentary scenes.\n6. Perform 'The Run' — an intense series of ever-shorter scenes at an increasingly breakneck pace. Anything goes as long as the pace consistently picks up.\n7. Return to the opening scene for the final (1.5-2 minutes) to wrap up the show. A classic technique is to go back in time, showing the characters before their conflict began.",
+        "variations": [],
+        "tips": [
+          "The opening scene is all about relationship and exploring the problem that is presented but not solved.",
+          "Commentary scenes should be game-heavy and focus on 'bits' — straight man vs. absurd man.",
+          "In 'The Run', pace is as important, if not more important, than content.",
+          "A classic finale technique is to go back in time, showing the characters before their conflict began, creating a poignant contrast."
+        ],
+        "referencedElements": [
+          "Del Close",
+          "The Family"
+        ]
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 1,
+        "refRecall": 1
+      }
+    },
+    {
+      "elementId": "game-concept",
+      "name": "Game",
+      "category": "concept-no-howtoplay",
+      "source": "ircwiki",
+      "lang": "en",
+      "expected": {
+        "description": "\"Game\" is a foundational improv concept with distinct meanings in shortform and longform. In shortform, a game is a set of pre-determined rules governing a scene's structure. In longform, the \"game of the scene\" is the interesting or funny pattern discovered during improvisation. Finding the game involves identifying the situation, spotting the first unusual thing, and asking \"if this is true, then what else is true?\" to heighten the pattern.",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [
+          "In shortform, a game is a set of pre-determined rules that govern the general structure of any scene.",
+          "In longform, find the game by answering three questions: What is the situation? What is the first unusual thing? If this is true, then what else is true?",
+          "The situation (who, where, what) can be established very quickly — within a few lines, or even through environment and object work before anyone speaks."
+        ],
+        "referencedElements": []
+      },
+      "actual": {
+        "description": "Game is an improvisational concept with different meanings in shortform and longform improv. In shortform, 'game' refers to a set of pre-determined rules governing a scene's structure. In longform, 'game' describes what is interesting or funny about an improvisational scene, discovered by identifying the situation, the first unusual thing, and exploring patterns through 'if this is true, then what else is true?'",
+        "howToPlay": null,
+        "variations": [],
+        "tips": [
+          "To find the game in a longform scene, ask three questions: What is the situation? What is the first unusual thing? If this is true, then what else is true?",
+          "The situation (who, where, what) can be established very quickly within a few lines.",
+          "The first unusual thing is the first thing a character does or says that sticks out like a sore thumb within the given situation.",
+          "Once you know what is out of the ordinary, explore and heighten that pattern by asking 'if this is true, what else is true?'"
+        ],
+        "referencedElements": []
+      },
+      "scores": {
+        "descOk": true,
+        "howToPlayOk": true,
+        "varCountMatch": true,
+        "varRecall": 1,
+        "tipRecall": 0.3333333333333333,
+        "refRecall": 1
+      }
+    }
+  ]
+}

--- a/src/normalize/__testdata__/run-benchmark.ts
+++ b/src/normalize/__testdata__/run-benchmark.ts
@@ -1,0 +1,336 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import TurndownService from "turndown";
+import { goldenSet } from "./golden-set";
+import type { GoldenOutput } from "./golden-set";
+
+const turndown = new TurndownService({ headingStyle: "atx" });
+
+const MODELS = [
+  { id: "pro" as const, model: "opencode-go/deepseek-v4-pro", label: "deepseek-v4-pro" },
+  { id: "flash" as const, model: "opencode-go/deepseek-v4-flash", label: "deepseek-v4-flash" },
+];
+
+function getApiKey(): string {
+  if (process.env.OPENCODE_GO_API_KEY) return process.env.OPENCODE_GO_API_KEY;
+  try {
+    const auth = JSON.parse(
+      readFileSync(join(homedir(), ".local/share/opencode/auth.json"), "utf-8"),
+    );
+    return auth["opencode-go"]?.key || "";
+  } catch {
+    console.error("No API key found. Set OPENCODE_GO_API_KEY or ensure ~/.local/share/opencode/auth.json exists.");
+    process.exit(1);
+  }
+}
+
+function buildBatchPrompt(): string {
+  let prompt = `Extract structured fields from each of the ${goldenSet.length} improv elements below. Return a JSON array of ${goldenSet.length} objects — no explanations, no markdown, no backticks.
+
+For each element return:
+{
+  "id": "element-id",
+  "description": "1-3 sentence summary in the element's language",
+  "howToPlay": "numbered step-by-step instructions. Use null ONLY if this is a theoretical concept page with no actionable steps (e.g. an improv theory article). ALL games, exercises, warm-ups, show formats, and handles MUST have step-by-step howToPlay instructions.",
+  "variations": [{"name": "variation name", "description": "brief description of the variation"}],
+  "tips": ["tip", "another tip"],
+  "referencedElements": ["name of another improv element mentioned"]
+}
+
+Important: 
+- howToPlay is null ONLY for pure theory/concept pages (like "Game" or "Status" as improv concepts).
+- Every game, exercise, warmup, show format, or handle MUST have numbered howToPlay steps extracted from the markdown.
+- For ask-for prompts (element names that are questions), howToPlay should be null and description should note it's an audience prompt.
+
+Elements to extract:
+`;
+
+  for (const e of goldenSet) {
+    const md = turndown.turndown(e.input.htmlContent).trim();
+    const lang = e.input.languageCode === "de" ? "German" : "English";
+    prompt += `
+---
+ID: ${e.id}
+Name: ${e.input.name}
+Language: ${lang}
+Source: ${e.input.sourceName}
+Markdown:
+${md || "(blank — this is an audience ask-for prompt, not a game)"}
+---`;
+  }
+
+  prompt += `\n\nReturn EXACTLY a JSON array of ${goldenSet.length} objects. No other text.`;
+  return prompt;
+}
+
+function extractJsonArray(text: string): any[] {
+  const mdMatch = text.match(/```(?:json)?\s*\n?(\[[\s\S]*?\])\n?```/);
+  const jsonStr = mdMatch ? mdMatch[1].trim() : text.trim();
+  const arrMatch = jsonStr.match(/\[[\s\S]*\]/);
+  const finalStr = arrMatch ? arrMatch[0] : jsonStr;
+  return JSON.parse(finalStr);
+}
+
+async function callOpenCodeGo(prompt: string, model: string): Promise<string> {
+  const promptFile = `/tmp/improbib-benchmark-${Date.now()}.txt`;
+  await Bun.write(promptFile, prompt);
+
+  try {
+    const proc = Bun.spawn(
+      ["sh", "-c", `cat ${promptFile} | opencode run --model ${model} --format json --dangerously-skip-permissions 2>/dev/null`],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    const events = output
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(Boolean);
+
+    const text = events
+      .filter((e: any) => e.type === "text")
+      .map((e: any) => e.part?.text || e.text || "")
+      .join("");
+
+    if (!text) {
+      console.error("  No text output. Event types:", events.map((e: any) => e.type).join(", "));
+      throw new Error("No text in model output");
+    }
+
+    return text;
+  } finally {
+    Bun.file(promptFile).delete().catch(() => {});
+  }
+}
+
+interface Result {
+  elementId: string;
+  name: string;
+  category: string;
+  source: string;
+  lang: string;
+  expected: GoldenOutput;
+  actual: GoldenOutput | null;
+  error?: string;
+  scores: {
+    descOk: boolean;
+    howToPlayOk: boolean;
+    varCountMatch: boolean;
+    varRecall: number;
+    tipRecall: number;
+    refRecall: number;
+  };
+}
+
+function normalizeOutput(raw: any): GoldenOutput {
+  return {
+    description: String(raw.description || ""),
+    howToPlay: raw.howToPlay ?? null,
+    variations: (raw.variations || []).map((v: any) => ({
+      name: String(v.name || ""),
+      description: String(v.description || ""),
+    })),
+    tips: (raw.tips || []).map(String),
+    referencedElements: (raw.referencedElements || []).map(String),
+  };
+}
+
+function scoreResult(expected: GoldenOutput, actual: GoldenOutput) {
+  const descOk = actual.description.length >= 20;
+  const howToPlayOk = expected.howToPlay === null
+    ? actual.howToPlay === null
+    : actual.howToPlay !== null && (actual.howToPlay as string).length >= 10;
+
+  const expectedVarNames = new Set(expected.variations.map((v) => v.name.toLowerCase()));
+  const actualVarNames = new Set(actual.variations.map((v) => v.name.toLowerCase()));
+  const varRecall = expectedVarNames.size === 0
+    ? 1.0
+    : [...expectedVarNames].filter((n) => actualVarNames.has(n)).length / expectedVarNames.size;
+
+  const expectedTipWords = expected.tips.flatMap((t) => t.toLowerCase().split(/\s+/));
+  const actualTipText = actual.tips.join(" ").toLowerCase();
+  const tipRecall = expected.tips.length === 0
+    ? 1.0
+    : expected.tips.filter((t) => {
+        const words = t.toLowerCase().split(/\s+/).filter((w) => w.length > 3);
+        return words.filter((w) => actualTipText.includes(w)).length / Math.max(words.length, 1) > 0.5;
+      }).length / expected.tips.length;
+
+  const expectedRefs = new Set(expected.referencedElements.map((r) => r.toLowerCase()));
+  const actualRefs = new Set(actual.referencedElements.map((r) => r.toLowerCase()));
+  const refRecall = expectedRefs.size === 0
+    ? 1.0
+    : [...expectedRefs].filter((r) => actualRefs.has(r)).length / expectedRefs.size;
+
+  const varCountMatch = Math.abs(actual.variations.length - expected.variations.length) <= 2;
+
+  return { descOk, howToPlayOk, varCountMatch, varRecall, tipRecall, refRecall };
+}
+
+async function getOpencodeVersion(): Promise<string> {
+  try {
+    const proc = Bun.spawn(["opencode", "--version"], { stdout: "pipe" });
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    return out.trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+async function main() {
+  const targetModel = Bun.argv[2];
+
+  const modelsToRun = targetModel
+    ? MODELS.filter((m) => m.id === targetModel)
+    : MODELS;
+
+  if (targetModel && modelsToRun.length === 0) {
+    console.error(`Unknown model: ${targetModel}. Options: ${MODELS.map((m) => m.id).join(", ")}`);
+    process.exit(1);
+  }
+
+  const opencodeVersion = await getOpencodeVersion();
+  const runTimestamp = new Date().toISOString();
+  const runId = runTimestamp.replace(/[:.]/g, "-");
+
+  console.log(`API Key: ${getApiKey().slice(0, 8)}...`);
+  console.log(`OpenCode: ${opencodeVersion}`);
+  console.log(`Run:      ${runTimestamp}`);
+  console.log(`Running ${modelsToRun.length} model(s) against ${goldenSet.length} golden elements\n`);
+
+  const allResults: Record<string, Result[]> = {};
+
+  for (const m of modelsToRun) {
+    const prompt = buildBatchPrompt();
+    console.log(`${m.label.toUpperCase()} — prompt: ${prompt.length} chars`);
+
+    const start = Date.now();
+    let rawOutput: string;
+    try {
+      rawOutput = await callOpenCodeGo(prompt, m.model);
+    } catch (err: any) {
+      console.error(`  FAILED: ${err.message}`);
+      continue;
+    }
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+    console.log(`  Completed in ${elapsed}s (${rawOutput.length} chars output)`);
+
+    let outputs: any[];
+    try {
+      outputs = extractJsonArray(rawOutput);
+    } catch (err: any) {
+      console.error(`  JSON parse FAILED: ${err.message}`);
+      console.error(`  First 300 chars: ${rawOutput.slice(0, 300)}`);
+      continue;
+    }
+
+    if (outputs.length !== goldenSet.length) {
+      console.error(`  Expected ${goldenSet.length} outputs, got ${outputs.length}`);
+    }
+
+    const results: Result[] = goldenSet.map((entry, i) => {
+      const raw = outputs[i] || {};
+      const actual = normalizeOutput(raw);
+      return {
+        elementId: entry.id,
+        name: entry.input.name,
+        category: entry.category,
+        source: entry.input.sourceName,
+        lang: entry.input.languageCode,
+        expected: entry.expectedOutput,
+        actual,
+        scores: scoreResult(entry.expectedOutput, actual),
+      };
+    });
+
+    allResults[m.id] = results;
+
+    const outFile = `src/normalize/__testdata__/results/${m.id}-results.json`;
+    await Bun.write(outFile, JSON.stringify({
+      meta: {
+        model: m.label,
+        modelId: m.model,
+        opencodeVersion,
+        timestamp: runTimestamp,
+        runId,
+        elementCount: goldenSet.length,
+        promptChars: prompt.length,
+        outputChars: rawOutput.length,
+        elapsedSeconds: parseFloat(elapsed),
+      },
+      results,
+    }, null, 2));
+    console.log(`  Wrote ${outFile}`);
+
+    // Quick stats
+    const descOk = results.filter((r) => r.scores.descOk).length;
+    const howOk = results.filter((r) => r.scores.howToPlayOk).length;
+    const avgVar = results.reduce((s, r) => s + r.scores.varRecall, 0) / results.length;
+    const avgTip = results.reduce((s, r) => s + r.scores.tipRecall, 0) / results.length;
+    const avgRef = results.reduce((s, r) => s + r.scores.refRecall, 0) / results.length;
+    const overall = ((descOk + howOk) / (results.length * 2) + (avgVar + avgTip + avgRef) / 3) / 2;
+
+    console.log(`  Descriptions: ${descOk}/${results.length}`);
+    console.log(`  howToPlay:    ${howOk}/${results.length}`);
+    console.log(`  Var recall:   ${(avgVar * 100).toFixed(0)}%`);
+    console.log(`  Tip recall:   ${(avgTip * 100).toFixed(0)}%`);
+    console.log(`  Ref recall:   ${(avgRef * 100).toFixed(0)}%`);
+    console.log(`  OVERALL:      ${(overall * 100).toFixed(0)}%\n`);
+  }
+
+  // ── Comparison ──
+  if (Object.keys(allResults).length >= 2) {
+    console.log("═══ COMPARISON ═══");
+    console.log(`{"Element":15,"Pro":15,"Flash":15}`.replace(/\d+/g, (m) => "─".repeat(parseInt(m))));
+    console.log(
+      ` │ ${"Element".padEnd(22)} │ ${"Pro".padEnd(6)} │ ${"Flash".padEnd(6)} │`,
+    );
+
+    for (const entry of goldenSet) {
+      const pro = allResults["pro"]?.find((r) => r.elementId === entry.id);
+      const flash = allResults["flash"]?.find((r) => r.elementId === entry.id);
+
+      const scoreEmoji = (ok: boolean) => ok ? "✓" : "✗";
+      const proOk = pro ? scoreEmoji(pro.scores.descOk && pro.scores.howToPlayOk) : "—";
+      const flashOk = flash ? scoreEmoji(flash.scores.descOk && flash.scores.howToPlayOk) : "—";
+
+      console.log(
+        ` │ ${entry.id.padEnd(22).slice(0, 22)} │ ${proOk.padEnd(6)} │ ${flashOk.padEnd(6)} │`,
+      );
+    }
+
+    const compFile = "src/normalize/__testdata__/results/comparison.json";
+    await Bun.write(compFile, JSON.stringify({
+      meta: {
+        opencodeVersion,
+        timestamp: runTimestamp,
+        runId,
+        elementCount: goldenSet.length,
+      },
+      models: MODELS.map((m) => ({
+        id: m.id,
+        label: m.label,
+        modelId: m.model,
+        results: allResults[m.id],
+        summary: {
+          descOk: (allResults[m.id] || []).filter((r) => r.scores.descOk).length,
+          howOk: (allResults[m.id] || []).filter((r) => r.scores.howToPlayOk).length,
+          avgVarRecall: (allResults[m.id] || []).reduce((s, r) => s + r.scores.varRecall, 0) / Math.max((allResults[m.id] || []).length, 1),
+          avgTipRecall: (allResults[m.id] || []).reduce((s, r) => s + r.scores.tipRecall, 0) / Math.max((allResults[m.id] || []).length, 1),
+          avgRefRecall: (allResults[m.id] || []).reduce((s, r) => s + r.scores.refRecall, 0) / Math.max((allResults[m.id] || []).length, 1),
+        },
+      })),
+    }, null, 2));
+    console.log(`\nWrote ${compFile}`);
+  }
+}
+
+main().catch(console.error);

--- a/src/normalize/cross-source-matching.ts
+++ b/src/normalize/cross-source-matching.ts
@@ -1,0 +1,100 @@
+/**
+ * Cross-source element matching using name similarity.
+ *
+ * Given lists of elements from different sources, finds pairs that
+ * likely refer to the same improv game/exercise, enabling the graph
+ * layer to merge them with source attribution.
+ */
+
+export interface MatchCandidate {
+  identifier: string;
+  name: string;
+  sourceName: string;
+  languageCode: string;
+}
+
+export interface MatchPair {
+  a: MatchCandidate;
+  b: MatchCandidate;
+  score: number;
+}
+
+function normalizeForMatch(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9äöüß ]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenOverlap(a: string, b: string): number {
+  const tokensA = new Set(a.split(" ").filter((t) => t.length > 1));
+  const tokensB = new Set(b.split(" ").filter((t) => t.length > 1));
+  if (tokensA.size === 0 || tokensB.size === 0) return 0;
+  const intersection = new Set([...tokensA].filter((t) => tokensB.has(t)));
+  return intersection.size / Math.max(tokensA.size, tokensB.size);
+}
+
+/**
+ * Find pairs of elements from different sources with similar names.
+ * Returns pairs with score >= threshold (0.0 to 1.0).
+ */
+export function findCrossSourceMatches(
+  candidates: MatchCandidate[],
+  threshold: number = 0.8,
+): MatchPair[] {
+  const matches: MatchPair[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < candidates.length; i++) {
+    for (let j = i + 1; j < candidates.length; j++) {
+      const a = candidates[i];
+      const b = candidates[j];
+
+      // Only match across sources and languages
+      if (a.sourceName === b.sourceName) continue;
+
+      const key = `${a.identifier}:${b.identifier}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const nameA = normalizeForMatch(a.name);
+      const nameB = normalizeForMatch(b.name);
+
+      // Exact match after normalization
+      if (nameA === nameB) {
+        matches.push({ a, b, score: 1.0 });
+        continue;
+      }
+
+      // Token overlap for similar names
+      const score = tokenOverlap(nameA, nameB);
+      if (score >= threshold) {
+        matches.push({ a, b, score: Math.round(score * 100) / 100 });
+      }
+    }
+  }
+
+  return matches.sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Build a map from element identifier to a list of related identifiers
+ * from other sources.
+ */
+export function buildRelatedIdentifiers(
+  candidates: MatchCandidate[],
+  threshold: number = 0.8,
+): Map<string, string[]> {
+  const matches = findCrossSourceMatches(candidates, threshold);
+  const related = new Map<string, string[]>();
+
+  for (const m of matches) {
+    if (!related.has(m.a.identifier)) related.set(m.a.identifier, []);
+    if (!related.has(m.b.identifier)) related.set(m.b.identifier, []);
+    related.get(m.a.identifier)!.push(m.b.identifier);
+    related.get(m.b.identifier)!.push(m.a.identifier);
+  }
+
+  return related;
+}

--- a/src/normalize/llm-client.ts
+++ b/src/normalize/llm-client.ts
@@ -1,0 +1,90 @@
+import TurndownService from "turndown";
+import type { GoldenOutput } from "./__testdata__/golden-set";
+
+const turndown = new TurndownService({ headingStyle: "atx" });
+
+export interface LlmClient {
+  normalizeElement(name: string, htmlContent: string, languageCode: string): Promise<GoldenOutput>;
+}
+
+export function createOpencodeGoClient(
+  model: string = "opencode-go/deepseek-v4-flash",
+): LlmClient {
+  return {
+    async normalizeElement(name, htmlContent, languageCode) {
+      const md = turndown.turndown(htmlContent).trim();
+      const lang = languageCode === "de" ? "German" : "English";
+
+      const prompt = `Extract structured fields from this improv element. Return ONLY a JSON object — no markdown, no backticks.
+
+Name: ${name}
+Language: ${lang}
+Content:
+${md || "(blank)"}
+
+Return: {"description":"1-3 sentence summary","howToPlay":"numbered steps or null for concepts/theory ONLY","variations":[{"name":"...","description":"..."}],"tips":["..."],"referencedElements":["name or empty"]}`;
+
+      const text = await callOpenCodeGo(prompt, model);
+      return extractJson(text);
+    },
+  };
+}
+
+async function callOpenCodeGo(prompt: string, model: string): Promise<string> {
+  const promptFile = `/tmp/improbib-nl-${Date.now()}.txt`;
+  await Bun.write(promptFile, prompt);
+
+  try {
+    const proc = Bun.spawn(
+      ["sh", "-c", `cat ${promptFile} | opencode run --model ${model} --format json --dangerously-skip-permissions 2>/dev/null`],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    const events = output
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(Boolean);
+
+    const text = events
+      .filter((e: any) => e.type === "text")
+      .map((e: any) => e.part?.text || e.text || "")
+      .join("");
+
+    if (!text) throw new Error("No text in model output");
+    return text;
+  } finally {
+    Bun.file(promptFile).delete().catch(() => {});
+  }
+}
+
+function normalizeHowToPlay(value: any): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => String(v)).join("\n");
+  }
+  return String(value);
+}
+
+function extractJson(text: string): GoldenOutput {
+  const mdMatch = text.match(/```(?:json)?\s*\n?(\{[\s\S]*?\})\n?```/);
+  const jsonStr = mdMatch ? mdMatch[1].trim() : text.trim();
+  const objMatch = jsonStr.match(/\{[\s\S]*\}/);
+  const finalStr = objMatch ? objMatch[0] : jsonStr;
+  const parsed = JSON.parse(finalStr);
+
+  return {
+    description: String(parsed.description || ""),
+    howToPlay: normalizeHowToPlay(parsed.howToPlay),
+    variations: (parsed.variations || []).map((v: any) => ({
+      name: String(v.name || ""),
+      description: String(v.description || ""),
+    })),
+    tips: (parsed.tips || []).map(String),
+    referencedElements: (parsed.referencedElements || []).map(String),
+  };
+}

--- a/src/normalize/normalize.ts
+++ b/src/normalize/normalize.ts
@@ -3,6 +3,7 @@ import { createHash } from "crypto";
 import type { ElementType } from "../scraping/shared/element-type";
 import { createOpencodeGoClient } from "./llm-client";
 import { normalizedSourceSchema, type NormalizedElement } from "./normalized-schema";
+import { buildRelatedIdentifiers } from "./cross-source-matching";
 
 interface LoadResult {
   meta: Record<string, any>;
@@ -167,5 +168,40 @@ export async function normalizeAll(): Promise<void> {
     } catch (err: any) {
       console.error(`Failed to normalize ${source}: ${err.message}`);
     }
+  }
+
+  // Cross-source matching: compute relatedIdentifiers across all sources
+  console.log("\nComputing cross-source matches...");
+  const allCandidates: { identifier: string; name: string; sourceName: string; languageCode: string }[] = [];
+
+  for (const source of ["improwiki", "learnimprov", "ircwiki"]) {
+    const f = Bun.file(path.join(outDir, `${source}.json`));
+    if (!(await f.exists())) continue;
+    const data = await f.json();
+    for (const el of data.elements || []) {
+      allCandidates.push({
+        identifier: el.identifier,
+        name: el.name,
+        sourceName: el.sourceName,
+        languageCode: el.languageCode,
+      });
+    }
+  }
+
+  const related = buildRelatedIdentifiers(allCandidates);
+  const matchCount = [...related.values()].reduce((s, ids) => s + ids.length, 0) / 2;
+  console.log(`Found ${matchCount} cross-source match pairs`);
+
+  // Update each source file with relatedIdentifiers
+  for (const source of ["improwiki", "learnimprov", "ircwiki"]) {
+    const srcPath = path.join(outDir, `${source}.json`);
+    const f = Bun.file(srcPath);
+    if (!(await f.exists())) continue;
+    const data = await f.json();
+    for (const el of data.elements || []) {
+      el.relatedIdentifiers = related.get(el.identifier) || [];
+    }
+    await Bun.write(srcPath, JSON.stringify(data, null, 2));
+    console.log(`  Updated ${source} with cross-source references`);
   }
 }

--- a/src/normalize/normalize.ts
+++ b/src/normalize/normalize.ts
@@ -1,0 +1,171 @@
+import path from "path";
+import { createHash } from "crypto";
+import type { ElementType } from "../scraping/shared/element-type";
+import { createOpencodeGoClient } from "./llm-client";
+import { normalizedSourceSchema, type NormalizedElement } from "./normalized-schema";
+
+interface LoadResult {
+  meta: Record<string, any>;
+  elements: ElementType[];
+}
+
+async function loadRaw(sourceName: string): Promise<LoadResult> {
+  const rawPath = path.join(process.cwd(), "output", "raw", `${sourceName}.json`);
+  const f = Bun.file(rawPath);
+  if (!(await f.exists())) {
+    throw new Error(`Raw file not found: ${rawPath}. Run fetch-raw or scrape first.`);
+  }
+  const data = await f.json();
+  return { meta: data.meta || {}, elements: data.elements || [] };
+}
+
+async function loadPreviousNormalized(sourceName: string): Promise<Map<string, NormalizedElement>> {
+  const prev = new Map<string, NormalizedElement>();
+  const prevPath = path.join(process.cwd(), "output", "normalized", `${sourceName}.json`);
+  const f = Bun.file(prevPath);
+  if (!(await f.exists())) return prev;
+  try {
+    const data = await f.json();
+    for (const e of data.elements || []) {
+      prev.set(e.identifier, e);
+    }
+  } catch { /* ignore corrupt previous file */ }
+  return prev;
+}
+
+function hashContent(html: string): string {
+  return createHash("md5").update(html).digest("hex");
+}
+
+export async function normalizeSource(sourceName: string, options?: { maxElements?: number }): Promise<void> {
+  const { meta, elements: allElements } = await loadRaw(sourceName);
+  const previous = await loadPreviousNormalized(sourceName);
+  const client = createOpencodeGoClient();
+
+  const elements = options?.maxElements
+    ? allElements.slice(0, options.maxElements)
+    : allElements;
+
+  console.log(`Normalizing ${sourceName}: ${elements.length}${options?.maxElements ? ` of ${allElements.length}` : ""} elements`);
+
+  const normalized: NormalizedElement[] = [];
+  let skipped = 0;
+  let extracted = 0;
+  const startTime = Date.now();
+
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i];
+    const contentHash = hashContent(el.htmlContent || "");
+
+    // Skip unchanged elements
+    const prev = previous.get(el.identifier);
+    if (prev?.normalized?.contentHash === contentHash) {
+      normalized.push(prev);
+      skipped++;
+      continue;
+    }
+
+    try {
+      const result = await client.normalizeElement(
+        el.name,
+        el.htmlContent as string || "",
+        el.languageCode,
+      );
+
+      // Promote variations with substantial descriptions to derived elements
+      const derivedElements = result.variations
+        .filter((v) => v.description.length > 40)
+        .map((v) => ({
+          name: v.name,
+          description: v.description,
+          parentIdentifier: el.identifier,
+        }));
+
+      const normalizedEl: NormalizedElement = {
+        identifier: el.identifier,
+        name: el.name,
+        url: el.url,
+        sourceName: el.sourceName,
+        languageCode: el.languageCode,
+        tags: el.tags,
+        htmlContent: el.htmlContent as string || "",
+        translationLinkEn: el.translationLinkEn,
+        translationLinkDe: el.translationLinkDe,
+        translationLinkEnIdentifier: el.translationLinkEnIdentifier,
+        translationLinkDeIdentifier: el.translationLinkDeIdentifier,
+        playerCountMin: el.playerCountMin,
+        playerCountMax: el.playerCountMax,
+        categories: el.categories,
+        postTags: el.postTags,
+        lastModified: el.lastModified,
+        normalized: {
+          description: result.description,
+          howToPlay: result.howToPlay,
+          variations: result.variations,
+          tips: result.tips,
+          referencedElements: result.referencedElements,
+          contentHash,
+          extractedAt: new Date().toISOString(),
+        },
+        derivedElements,
+      };
+
+      normalized.push(normalizedEl);
+      extracted++;
+
+      if ((i + 1) % 10 === 0 || i === elements.length - 1) {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        const rate = ((i + 1) / parseFloat(elapsed)).toFixed(1);
+        console.log(`  [${i + 1}/${elements.length}] ${sourceName}: ${extracted} new, ${skipped} cached (${rate}/s, ${elapsed}s)`);
+      }
+    } catch (err: any) {
+      console.warn(`  SKIP ${el.name}: ${err.message}`);
+      // Keep previous if available, otherwise skip
+      if (prev) normalized.push(prev);
+      else skipped++;
+    }
+  }
+
+  const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
+  const derivedCount = normalized.reduce((s, e) => s + e.derivedElements.length, 0);
+
+  const output = {
+    meta: {
+      sourceName,
+      elementCount: normalized.length,
+      derivedElementCount: derivedCount,
+      normalizedAt: new Date().toISOString(),
+    },
+    elements: normalized,
+  };
+
+  // Validate
+  const parsed = normalizedSourceSchema.safeParse(output);
+  if (!parsed.success) {
+    console.error(`Schema validation failed for ${sourceName}:`);
+    for (const issue of parsed.error.issues) {
+      console.error(`  ${issue.path.join(".")}: ${issue.message}`);
+    }
+  }
+
+  const outDir = path.join(process.cwd(), "output", "normalized");
+  await Bun.write(path.join(outDir, `${sourceName}.json`), JSON.stringify(parsed.success ? parsed.data : output, null, 2));
+
+  console.log(`Finished ${sourceName}: ${normalized.length} elements, ${derivedCount} derived, ${skipped} skipped, ${totalTime}s`);
+}
+
+export async function normalizeAll(): Promise<void> {
+  const outDir = path.join(process.cwd(), "output", "normalized");
+  const dir = Bun.file(outDir);
+  if (!(await dir.exists())) {
+    await Bun.$`mkdir -p ${outDir}`.quiet();
+  }
+
+  for (const source of ["improwiki", "learnimprov", "ircwiki"]) {
+    try {
+      await normalizeSource(source);
+    } catch (err: any) {
+      console.error(`Failed to normalize ${source}: ${err.message}`);
+    }
+  }
+}

--- a/src/normalize/normalized-schema.ts
+++ b/src/normalize/normalized-schema.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+export const normalizedElementSchema = z.object({
+  identifier: z.string().length(32),
+  name: z.string(),
+  url: z.string().url(),
+  sourceName: z.string(),
+  languageCode: z.enum(["de", "en"]),
+  tags: z.array(z.string()),
+  htmlContent: z.string(),
+
+  translationLinkEn: z.string().url().optional(),
+  translationLinkDe: z.string().url().optional(),
+  translationLinkEnIdentifier: z.string().length(32).optional(),
+  translationLinkDeIdentifier: z.string().length(32).optional(),
+
+  playerCountMin: z.number().optional(),
+  playerCountMax: z.number().optional(),
+  categories: z.array(z.string()).optional(),
+  postTags: z.array(z.string()).optional(),
+  lastModified: z.string().optional(),
+
+  normalized: z.object({
+    description: z.string().min(10),
+    howToPlay: z.string().nullable(),
+    variations: z.array(
+      z.object({
+        name: z.string(),
+        description: z.string(),
+      }),
+    ),
+    tips: z.array(z.string()),
+    referencedElements: z.array(z.string()),
+    contentHash: z.string(),
+    extractedAt: z.string(),
+  }),
+
+  relatedIdentifiers: z.array(z.string().length(32)),
+
+  derivedElements: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      parentIdentifier: z.string(),
+    }),
+  ),
+});
+
+export type NormalizedElement = z.infer<typeof normalizedElementSchema>;
+
+export const normalizedSourceSchema = z.object({
+  meta: z.object({
+    sourceName: z.string(),
+    elementCount: z.number(),
+    derivedElementCount: z.number(),
+    normalizedAt: z.string(),
+  }),
+  elements: z.array(normalizedElementSchema),
+});
+
+export type NormalizedSource = z.infer<typeof normalizedSourceSchema>;


### PR DESCRIPTION
## Summary

Implements the content normalization layer from Plan 0001. This is the first iteration — everything up to (but not including) Layer 2.

### What is included

**Golden Test Set (15 elements)**
- Covers edge cases across all 3 sources (improwiki, learnimprov, ircwiki)
- Both English and German content
- Ranges from minimal (24 chars) to very long (15K+ chars)
- Includes games, exercises, concepts, show formats, ask-fors
- Integrity tests validate structure and coverage

**Model Benchmark (run-benchmark.ts)**
- Compares deepseek-v4-pro vs deepseek-v4-flash against golden set
- Both models achieve 91-93% overall quality
- Results committed with metadata (opencode 1.15.5, timestamped)
- Adding a new model = one line in MODELS array

**Normalization Pipeline (normalize.ts)**
- Reads raw elements from output/raw/{source}.json
- Converts HTML to markdown via Turndown
- LLM extraction via opencode CLI (uses existing auth.json, no new API keys)
- Content hash caching — unchanged elements skip re-extraction
- Inline variations promoted to derivedElements
- Writes output/normalized/{source}.json

**Cross-Source Matching (cross-source-matching.ts)**
- Token-overlap name similarity for cross-source deduplication
- Adds relatedIdentifiers to each normalized element
- Graph layer (Layer 2) can use these to merge equivalent elements

**ADR-0008** — Documents normalization layer decisions

**Infrastructure**
- Adds OPENCODE_GO_API_KEY to deployment env vars (personal-infra)
- fetch-raw.ts to download data from deployed endpoint

### Test Results

37 tests: 36 pass, 1 skip, 0 fail

### What is NOT in this PR (deferred to Layer 2+)

- Knowledge graph derivation
- Human QA workflow
- Application layer (workshop planner, browser)
- Full cross-source merge (just matching in this layer)